### PR TITLE
Kite Status/Kite Install Checks

### DIFF
--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/components/status_model.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/components/status_model.ts
@@ -1,0 +1,163 @@
+import { VDomModel } from '@jupyterlab/apputils';
+import { PageConfig, URLExt } from '@jupyterlab/coreutils';
+import { ServerConnection } from '@jupyterlab/services';
+import { LabIcon } from '@jupyterlab/ui-components';
+
+import { JupyterLabWidgetAdapter } from '../jl_adapter';
+import { LSPConnection } from '../../../connection';
+import { DocumentConnectionManager } from '../../../connection_manager';
+import { ILanguageServerManager } from '../../../tokens';
+import { VirtualDocument } from '../../../virtual/document';
+
+import kiteLogo from '../../../../style/icons/kite-logo.svg';
+
+export interface IKiteStatus {
+  status: string;
+  short: string;
+  long: string;
+}
+/**
+ * A VDomModel for the LSP of current file editor/notebook.
+ */
+export class KiteStatusModel extends VDomModel {
+  private _connection_manager: DocumentConnectionManager;
+  private _icon: LabIcon = new LabIcon({
+    name: 'jupyterlab-kite:icon-name',
+    svgstr: kiteLogo
+  });
+  private _kiteStatus: IKiteStatus = { status: '', short: '', long: '' };
+
+  constructor() {
+    super();
+
+    this.icon.bindprops({ className: 'kite-logo' });
+  }
+
+  async fetchKiteInstalled(): Promise<void> {
+    const response = await ServerConnection.makeRequest(
+      this.kiteInstalledUrl,
+      { method: 'GET' },
+      ServerConnection.makeSettings()
+    );
+    if (!response.ok) {
+      console.warn('Could not fetch Kite Install status:', response.statusText);
+    }
+
+    let installed: boolean;
+    try {
+      installed = await response.json();
+      if (!installed && this.status.status !== 'not installed') {
+        this.status = {
+          status: 'not installed',
+          short: 'not installed',
+          long: 'Kite install could not be found.'
+        };
+      } else if (installed && this.status.status === 'not installed') {
+        this.reset();
+      }
+    } catch (err) {
+      console.warn(err);
+    }
+  }
+
+  get kiteInstalledUrl(): string {
+    return URLExt.join(
+      PageConfig.getBaseUrl(),
+      ILanguageServerManager.URL_NS,
+      'kite_installed'
+    );
+  }
+
+  get status(): IKiteStatus {
+    return this._kiteStatus;
+  }
+
+  set status(status: IKiteStatus) {
+    this._kiteStatus = status;
+    this.stateChanged.emit(void 0);
+  }
+
+  get icon(): LabIcon {
+    return this._icon;
+  }
+
+  get short_message(): string {
+    if (!this.adapter || !this.status.status) {
+      return 'Kite: not running';
+    }
+    return 'Kite: ' + this.status.short;
+  }
+
+  get long_message(): string {
+    if (!this.adapter || !this.status.status) {
+      return 'Kite is not reachable.';
+    }
+    return this.status.long;
+  }
+
+  get adapter(): JupyterLabWidgetAdapter | null {
+    return this._adapter;
+  }
+
+  set adapter(adapter: JupyterLabWidgetAdapter | null) {
+    if (this._adapter != null) {
+      this._adapter.status_message.changed.connect(this._onChange);
+    }
+
+    if (adapter != null) {
+      adapter.status_message.changed.connect(this._onChange);
+    }
+
+    this._adapter = adapter;
+  }
+
+  get connection_manager() {
+    return this._connection_manager;
+  }
+
+  set connection_manager(connection_manager) {
+    if (this._connection_manager != null) {
+      this._connection_manager.connected.disconnect(this._onChange);
+      this._connection_manager.initialized.connect(this._onChange);
+      this._connection_manager.disconnected.disconnect(this._onChange);
+      this._connection_manager.closed.disconnect(this._onChange);
+      this._connection_manager.documents_changed.disconnect(this._onChange);
+    }
+
+    if (connection_manager != null) {
+      connection_manager.connected.connect(this._onChange);
+      connection_manager.initialized.connect(this._onChange);
+      connection_manager.disconnected.connect(this._onChange);
+      connection_manager.closed.connect(this._onChange);
+      connection_manager.documents_changed.connect(this._onChange);
+    }
+
+    this._connection_manager = connection_manager;
+  }
+
+  get activeDocument(): VirtualDocument | undefined {
+    if (this.adapter && this.adapter.virtual_editor) {
+      return this.adapter.virtual_editor.virtual_document;
+    }
+    return undefined;
+  }
+
+  get activeConnection(): LSPConnection | undefined {
+    if (this.activeDocument) {
+      return this.connection_manager.connections.get(
+        this.activeDocument.id_path
+      );
+    }
+    return undefined;
+  }
+
+  reset() {
+    this.status = { status: '', short: '', long: '' };
+  }
+
+  private _onChange = () => {
+    this.stateChanged.emit(void 0);
+  };
+
+  private _adapter: JupyterLabWidgetAdapter | null = null;
+}

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/components/statusbar.tsx
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/components/statusbar.tsx
@@ -55,16 +55,6 @@ export class KiteStatus extends VDomRenderer<KiteStatus.Model> {
   }
 }
 
-type StatusCode = 'waiting' | 'initializing' | 'initialized' | 'connecting';
-
-export interface IStatus {
-  connected_documents: Set<VirtualDocument>;
-  initialized_documents: Set<VirtualDocument>;
-  open_connections: Array<LSPConnection>;
-  detected_documents: Set<VirtualDocument>;
-  status: StatusCode;
-}
-
 export namespace KiteStatus {
   /**
    * A VDomModel for the LSP of current file editor/notebook.

--- a/packages/jupyterlab-kite/src/index.ts
+++ b/packages/jupyterlab-kite/src/index.ts
@@ -40,6 +40,7 @@ import {
   DocumentRegistry
 } from '@jupyterlab/docregistry/lib/registry';
 import { DocumentConnectionManager } from './connection_manager';
+import { KiteStatusModel } from './adapters/jupyterlab/components/status_model';
 
 const lsp_commands: Array<IFeatureCommand> = [].concat(
   ...lsp_features.map(feature => feature.commands)
@@ -76,13 +77,14 @@ const plugin: JupyterFrontEndPlugin<void> = {
     status_bar: IStatusBar
   ) => {
     const language_server_manager = new LanguageServerManager({});
+    const kite_status_model = new KiteStatusModel();
     const connection_manager = new DocumentConnectionManager({
-      language_server_manager
+      language_server_manager,
+      kite_status_model
     });
 
-    const status_bar_item = new KiteStatus();
-    status_bar_item.model.language_server_manager = language_server_manager;
-    status_bar_item.model.connection_manager = connection_manager;
+    const status_bar_item = new KiteStatus(kite_status_model);
+    status_bar_item.model.connection_manager = connection_manager; // Check if references are updated
 
     labShell.currentChanged.connect(() => {
       const current = labShell.currentWidget;

--- a/py_src/jupyter_kite/handlers.py
+++ b/py_src/jupyter_kite/handlers.py
@@ -1,11 +1,13 @@
 """ tornado handler for managing and communicating with language servers
 """
+import json
 from typing import Optional, Text
 
 from notebook.base.handlers import IPythonHandler
 from notebook.base.zmqhandlers import WebSocketHandler, WebSocketMixin
 from notebook.utils import url_path_join as ujoin
 
+from .locator import KiteLocator
 from .manager import LanguageServerManager
 from .schema import SERVERS_RESPONSE
 
@@ -67,6 +69,22 @@ class LanguageServersHandler(BaseHandler):
         self.finish(response)
 
 
+class KiteInstalledHandler(BaseHandler):
+    """
+    Reports if Kite is installed
+    """
+
+    def initialize(self, *args, **kwargs):
+        super().initialize(*args, **kwargs)
+        self.locator = KiteLocator()
+
+    def get(self):
+        exists, _ = self.locator.check_if_kite_installed()
+        exists = json.dumps(exists)
+        response = exists
+        self.finish(response)
+
+
 def add_handlers(nbapp):
     """ Add Language Server routes to the notebook server web application
     """
@@ -84,5 +102,6 @@ def add_handlers(nbapp):
                 LanguageServerWebSocketHandler,
                 opts,
             ),
+            (ujoin(lsp_url, "kite_installed"), KiteInstalledHandler, opts),
         ],
     )

--- a/py_src/jupyter_kite/locator.py
+++ b/py_src/jupyter_kite/locator.py
@@ -1,0 +1,37 @@
+import os
+import os.path as osp
+import subprocess
+import sys
+
+
+class KiteLocator:
+    def check_if_kite_installed(self):
+        """Detect if kite is installed and return the installation path."""
+        path = ''
+        if os.name == 'nt':
+            path = 'C:\\Program Files\\Kite\\kited.exe'
+        elif sys.platform.startswith('linux'):
+            path = osp.expanduser('~/.local/share/kite/kited')
+        elif sys.platform == 'darwin':
+            path = self.locate_kite_darwin()
+        return osp.exists(osp.realpath(path)), path
+
+    def locate_kite_darwin(self):
+        """
+        Looks up where Kite.app is installed on macOS systems. The bundle ID
+        is checked first and if nothing is found or an error occurs, the
+        default path is used.
+        """
+        default_path = '/Applications/Kite.app'
+        path = ''
+        try:
+            out = subprocess.check_output(
+                ['mdfind', 'kMDItemCFBundleIdentifier="com.kite.Kite"'])
+            installed = len(out) > 0
+            path = (out.decode('utf-8', 'replace').strip().split('\n')[0]
+                    if installed else default_path)
+        except (subprocess.CalledProcessError, UnicodeDecodeError):
+            # Use the default path
+            path = default_path
+        finally:
+            return path


### PR DESCRIPTION
## Frontend
- Extracted model into own class `KiteModelStatus` to act as the source of truth.
- Model is used by `LSPConnection` to fire `kite/status` calls to the shim. This could not be done in `KiteModelStatus` without it being a child class of `LSPWsConnection`
- Model is used by `statusbar.tsx` to render the appropriate UI.

## Server extension
- Add route `lsp/kite_installed` and handler so frontend can query kite install information via the frontend
- Create class `KiteLocator` which reuses the Kite Install checks from Spyder