### PR TITLE
rerequest completions every keystroke

### DIFF
--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
@@ -32,7 +32,7 @@ export class KiteConnector extends DataConnector<
   virtual_editor: VirtualEditor;
   responseType = CompletionHandler.ICompletionItemsResponseType;
   private trigger_kind: CompletionTriggerKind;
-  private suppress_auto_invoke_in = ['comment', 'string'];
+  private suppress_auto_invoke_in = ['comment'];
   private icon: LabIcon;
 
   /**

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/file_editor.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/file_editor.ts
@@ -88,11 +88,14 @@ export class FileEditorAdapter extends JupyterLabWidgetAdapter {
       connections: this.connection_manager.connections,
       virtual_editor: this.virtual_editor
     });
-    this.completion_manager.register({
+    const handler = this.completion_manager.register({
       connector: this.current_completion_connector,
       editor: this.editor.editor,
       parent: this.widget
     });
+    if (handler instanceof CompletionHandler) {
+      this.completion_handler = handler;
+    }
   }
 
   get path() {

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/jl_adapter.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/jl_adapter.ts
@@ -4,6 +4,7 @@ import { JupyterFrontEnd } from '@jupyterlab/application';
 import { CodeJumper } from '@krassowski/jupyterlab_go_to_definition/lib/jumpers/jumper';
 import { PositionConverter } from '../../converter';
 import { CodeEditor } from '@jupyterlab/codeeditor';
+import { CompletionHandler } from '@jupyterlab/completer';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { DocumentRegistry, IDocumentWidget } from '@jupyterlab/docregistry';
 
@@ -118,6 +119,8 @@ export abstract class JupyterLabWidgetAdapter
   public connection_manager: DocumentConnectionManager;
   public status_message: StatusMessage;
   public isDisposed = false;
+
+  completion_handler?: CompletionHandler;
 
   protected constructor(
     protected app: JupyterFrontEnd,
@@ -264,6 +267,12 @@ export abstract class JupyterLabWidgetAdapter
   abstract find_ce_editor(cm_editor: CodeMirror.Editor): CodeEditor.IEditor;
 
   invoke_completer(kind: CompletionTriggerKind) {
+    if (this.completion_handler) {
+      const model = this.completion_handler.completer.model;
+      if (model) {
+        model.reset(true);
+      }
+    }
     this.current_completion_connector.with_trigger_kind(kind, () => {
       return this.app.commands.execute(this.invoke_command);
     });

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/notebook.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/notebook.ts
@@ -191,8 +191,11 @@ export class NotebookAdapter extends JupyterLabWidgetAdapter {
       connector: this.current_completion_connector,
       editor: cell.editor,
       parent: this.widget
-    });
+    }) as CompletionHandler;
     this.current_completion_handler = handler;
+    if (handler instanceof CompletionHandler) {
+      this.completion_handler = handler;
+    }
     this.widget.content.activeCellChanged.connect(this.on_completions, this);
   }
 

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/notebook.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/notebook.ts
@@ -191,7 +191,7 @@ export class NotebookAdapter extends JupyterLabWidgetAdapter {
       connector: this.current_completion_connector,
       editor: cell.editor,
       parent: this.widget
-    }) as CompletionHandler;
+    });
     this.current_completion_handler = handler;
     if (handler instanceof CompletionHandler) {
       this.completion_handler = handler;


### PR DESCRIPTION
even when completions are already visible

The approach I take here is to clear completions before re-requesting, which causes the dialog to flicker. I think this is possible to fix by updating the completions model, instead of resetting it.

But updating the model will probably have complicated interactions with the fix for #11159.