### PR TITLE
Remove token type-check before fetching completions

### DIFF
--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
@@ -77,9 +77,6 @@ export class KiteConnector extends DataConnector<
     const cursor = editor.getCursorPosition();
     const token = editor.getTokenForPosition(cursor);
 
-    if (!token.type) {
-      console.log('[Kite][Completer] No token type found');
-    }
     if (this.suppress_auto_invoke_in.indexOf(token.type) !== -1) {
       console.log(
         '[Kite][Completer] Suppressing completer auto-invoke in',

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
@@ -79,7 +79,6 @@ export class KiteConnector extends DataConnector<
 
     if (!token.type) {
       console.log('[Kite][Completer] No token type found');
-      return;
     }
     if (this.suppress_auto_invoke_in.indexOf(token.type) !== -1) {
       console.log(

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
@@ -77,7 +77,7 @@ export class KiteConnector extends DataConnector<
     const cursor = editor.getCursorPosition();
     const token = editor.getTokenForPosition(cursor);
 
-    if (this.suppress_auto_invoke_in.indexOf(token.type) !== -1) {
+    if (token.type && this.suppress_auto_invoke_in.indexOf(token.type) !== -1) {
       console.log(
         '[Kite][Completer] Suppressing completer auto-invoke in',
         token.type

--- a/yarn.lock
+++ b/yarn.lock
@@ -1370,7 +1370,7 @@
     typestyle "^2.0.4"
 
 "@kiteco/jupyterlab-kite@file:packages/jupyterlab-kite":
-  version "1.0.0"
+  version "0.0.1"
   dependencies:
     "@krassowski/jupyterlab_go_to_definition" "~1.0.0"
     lsp-ws-connection "~0.4.0"


### PR DESCRIPTION
token `.` has no type, and so completions do not get fetched in cases like `np.$`.

Does this check prevent any known bad behavior?