### PR TITLE
Accomodate ([{ auto-close in completion fetching

### DIFF
--- a/packages/jupyterlab-kite/src/adapters/codemirror/features/completion.ts
+++ b/packages/jupyterlab-kite/src/adapters/codemirror/features/completion.ts
@@ -3,7 +3,7 @@ import * as CodeMirror from 'codemirror';
 import { CodeMirrorLSPFeature } from '../feature';
 
 // Defines text insertions that are >1 char and do not suppress the completer
-const allowedLongChanges: string[] = ['()', '[]', '{}', '""', "''"];
+const allowedLongChanges: Set<string> = new Set(['()', '[]', '{}', '""', "''"]);
 
 export class Completion extends CodeMirrorLSPFeature {
   name = 'Completion';
@@ -29,7 +29,7 @@ export class Completion extends CodeMirrorLSPFeature {
     if (
       change.text.length &&
       change.text[0].length > 1 &&
-      !allowedLongChanges.includes(change.text[0])
+      !allowedLongChanges.has(change.text[0])
     ) {
       // Return early to prevent completions list from
       // popping up right away after a completion is inserted.

--- a/packages/jupyterlab-kite/src/adapters/codemirror/features/completion.ts
+++ b/packages/jupyterlab-kite/src/adapters/codemirror/features/completion.ts
@@ -23,10 +23,12 @@ export class Completion extends CodeMirrorLSPFeature {
   afterChange(change: CodeMirror.EditorChange): void {
     // TODO: maybe the completer could be kicked off in the handleChange() method directly; signature help still
     //  requires an up-to-date virtual document on the LSP side, so we need to wait for sync.
-    if (change.text.length && change.text[0].length > 1) {
-      // Use text[0].length => 1 as a proxy for a keystroke.
+    if (change.text.length && change.text[0].length > 2) {
       // Return early to prevent completions list from
       // popping up right away after a completion is inserted.
+      this.virtual_editor.console.log(
+        'Suppressing completion list due to text change >2 char'
+      );
       return;
     }
     let last_character = this.extract_last_character(change);

--- a/packages/jupyterlab-kite/src/adapters/codemirror/features/completion.ts
+++ b/packages/jupyterlab-kite/src/adapters/codemirror/features/completion.ts
@@ -2,6 +2,9 @@ import { CompletionTriggerKind } from '../../../lsp';
 import * as CodeMirror from 'codemirror';
 import { CodeMirrorLSPFeature } from '../feature';
 
+// Defines text insertions that are >1 char and do not suppress the completer
+const allowedLongChanges: string[] = ['()', '[]', '{}'];
+
 export class Completion extends CodeMirrorLSPFeature {
   name = 'Completion';
   private _completionCharacters: string[];
@@ -23,11 +26,16 @@ export class Completion extends CodeMirrorLSPFeature {
   afterChange(change: CodeMirror.EditorChange): void {
     // TODO: maybe the completer could be kicked off in the handleChange() method directly; signature help still
     //  requires an up-to-date virtual document on the LSP side, so we need to wait for sync.
-    if (change.text.length && change.text[0].length > 2) {
+    if (
+      change.text.length &&
+      change.text[0].length > 1 &&
+      !allowedLongChanges.includes(change.text[0])
+    ) {
       // Return early to prevent completions list from
       // popping up right away after a completion is inserted.
       this.virtual_editor.console.log(
-        'Suppressing completion list due to text change >2 char'
+        'Suppressing completion list due to multi-character text change: ',
+        change.text[0]
       );
       return;
     }

--- a/packages/jupyterlab-kite/src/adapters/codemirror/features/completion.ts
+++ b/packages/jupyterlab-kite/src/adapters/codemirror/features/completion.ts
@@ -3,7 +3,7 @@ import * as CodeMirror from 'codemirror';
 import { CodeMirrorLSPFeature } from '../feature';
 
 // Defines text insertions that are >1 char and do not suppress the completer
-const allowedLongChanges: string[] = ['()', '[]', '{}'];
+const allowedLongChanges: string[] = ['()', '[]', '{}', '""', "''"];
 
 export class Completion extends CodeMirrorLSPFeature {
   name = 'Completion';


### PR DESCRIPTION
Currently completions are not fetched in the case where a user enters one of `([{` because the closing equivalent `}])` is added, which constitutes a text change of length 2.