### PR TITLE
Change completer width styling

### DIFF
--- a/packages/jupyterlab-kite/style/icons/kite-logo.svg
+++ b/packages/jupyterlab-kite/style/icons/kite-logo.svg
@@ -1,4 +1,4 @@
-<svg width="24px" height="24px" viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg" style="vertical-align: middle">
+<svg width="24px" height="24px" viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg">
     <g id="kite-logo" transform="translate(53,14)">
         <polygon id="Path" points="150.433658 147.335971 90.1889836 260.668594 221.53804 372.861838 264.798844 205.622337 150.433658 147.335971"></polygon>
         <polygon id="Path" points="104.003956 0 0 183.653682 79.7565429 251.767194 146.303408 134.23311 268.252587 192.341449 294.529519 90.7942788 104.003956 0"></polygon>

--- a/packages/jupyterlab-kite/style/index.css
+++ b/packages/jupyterlab-kite/style/index.css
@@ -1,9 +1,27 @@
 @import url('./highlight.css');
 @import url('./logo.css');
 
+/* All the stylings below this point should eventually be contributed upstream to jupyterlab/jupyterlab */
 .jp-Completer-docpanel {
   overflow: auto;
 }
 .jp-Completer-docpanel.hidden {
   display: none;
+}
+
+.jp-Completer-type {
+  min-width: 24px;
+  vertical-align: middle;
+}
+
+.jp-Completer-icon svg {
+  vertical-align: middle;
+}
+
+.jp-Completer-match {
+  min-width: 180px;
+}
+
+.jp-Completer-typeExtended {
+  min-width: 70px;
 }

--- a/packages/jupyterlab-kite/style/index.css
+++ b/packages/jupyterlab-kite/style/index.css
@@ -1,7 +1,6 @@
 @import url('./highlight.css');
 @import url('./logo.css');
 
-/* All the stylings below this point should eventually be contributed upstream to jupyterlab/jupyterlab */
 .jp-Completer-docpanel {
   overflow: auto;
 }

--- a/packages/jupyterlab-kite/style/index.css
+++ b/packages/jupyterlab-kite/style/index.css
@@ -9,9 +9,18 @@
   display: none;
 }
 
+.jp-Completer-list {
+  scrollbar-width: thin;
+}
+
 .jp-Completer-type {
+  display: table-cell;
   min-width: 24px;
   vertical-align: middle;
+}
+
+.jp-Completer-monogram {
+  display: table-cell;
 }
 
 .jp-Completer-icon svg {
@@ -19,9 +28,12 @@
 }
 
 .jp-Completer-match {
+  max-width: 320px;
   min-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .jp-Completer-typeExtended {
-  min-width: 70px;
+  padding-left: 40px;
 }


### PR DESCRIPTION
Fixes kiteco/kiteco#11181

Reduces the variance in completer width as you type, and also makes completion lists with only short completions feel less cramped.

These style changes should be upstreamed to jupyterlab core, but we can patch them in the extension for now.