### PR TITLE
Reintegrate Kernel Completions

### DIFF
--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
@@ -284,7 +284,9 @@ export class KiteConnector extends DataConnector<
       types.forEach((item: JSONObject) => {
         const text = item.text as string;
         const type = item.type as string;
-        items.push({ label: text, type });
+        if (type !== '<unknown>') {
+          items.push({ label: text, type });
+        }
       });
     } else {
       const matches = reply.matches;

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
@@ -155,20 +155,12 @@ export class KiteConnector extends DataConnector<
       document,
       position_in_token
     ).catch(_ => {
-      return {
-        start: -1,
-        end: -1,
-        items: []
-      } as CompletionHandler.ICompletionItemsReply;
-    });
+      return KiteConnector.EmptyICompletionItemsReply;
+    }) as Promise<CompletionHandler.ICompletionItemsReply>;
+
     const kernelPromise = this._kernel_connector.fetch(request).catch(_ => {
-      return {
-        start: -1,
-        end: -1,
-        matches: [],
-        metadata: {}
-      } as CompletionHandler.IReply;
-    });
+      return KiteConnector.EmptyIReply;
+    }) as Promise<CompletionHandler.IReply>;
 
     const [kernel, kite] = await Promise.all([kernelPromise, kitePromise]);
     return this.merge_replies(kernel, kite);
@@ -355,4 +347,17 @@ export namespace KiteConnector {
 
     session?: Session.ISessionConnection;
   }
+
+  export const EmptyICompletionItemsReply = {
+    start: -1,
+    end: -1,
+    items: [] as CompletionHandler.ICompletionItems
+  };
+
+  export const EmptyIReply = {
+    start: -1,
+    end: -1,
+    matches: [] as ReadonlyArray<string>,
+    metadata: {}
+  };
 }

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
@@ -128,7 +128,13 @@ export class KiteConnector extends DataConnector<
       cursor_in_root
     );
 
-    if (!this._kernel_connector || !request) {
+    /**
+     * Don't fetch kernel completions if:
+     * - No kernel connector
+     * - No request object
+     * - Token type is string (otherwise kernel completions appear within docstrings)
+     */
+    if (!this._kernel_connector || !request || token.type === 'string') {
       return this.fetch_kite(
         token,
         typed_character,
@@ -264,13 +270,13 @@ export class KiteConnector extends DataConnector<
       return newKernelReply;
     }
 
-    // Dedupe Kernel labels with Kite insertTexts
-    const kiteSet = new Set(kiteReply.items.map(item => item.insertText));
+    // Dedupe Kite and Kernel items based on label
+    const kiteSet = new Set(kiteReply.items.map(item => item.label));
     newKernelReply.items = newKernelReply.items.filter(
       item => !kiteSet.has(item.label)
     );
 
-    console.log('[Kite]: Merging', newKernelReply, kiteReply);
+    console.log('[Kite]: Merging', kiteReply, newKernelReply);
     return {
       ...kiteReply,
       items: kiteReply.items.concat(newKernelReply.items)

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
@@ -156,14 +156,12 @@ export class KiteConnector extends DataConnector<
         document,
         position_in_token
       ).catch(() => {
-        console.log('kitePromiseReject -- Returning EmptyIReply');
         return KiteConnector.EmptyICompletionItemsReply;
       });
     };
 
     const kernelPromise = () => {
       return this._kernel_connector.fetch(request).catch(() => {
-        console.log('kernelPromiseReject -- Returning EmptyIReply');
         return KiteConnector.EmptyIReply;
       });
     };
@@ -178,7 +176,6 @@ export class KiteConnector extends DataConnector<
     };
 
     const isManual = this._trigger_kind === CompletionTriggerKind.Invoked;
-    console.log('Manual:', isManual);
 
     const [kernel, kite] = await Promise.all([
       isManual ? kernelPromise() : kernelTimeoutPromise(),
@@ -272,15 +269,12 @@ export class KiteConnector extends DataConnector<
     kernelReply: CompletionHandler.IReply,
     kiteReply: CompletionHandler.ICompletionItemsReply
   ): CompletionHandler.ICompletionItemsReply {
-    console.log('[Kite]: Attempting to merge...', kernelReply, kiteReply);
     const newKernelReply = this.transform(kernelReply);
 
     if (!newKernelReply.items.length) {
-      console.log('[Kite]: No kernel items, returning Kite reply');
       return kiteReply;
     }
     if (!kiteReply.items.length) {
-      console.log('[Kite]: No Kite items, returning kernel reply');
       return newKernelReply;
     }
 

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
@@ -263,7 +263,14 @@ export class KiteConnector extends DataConnector<
       console.log('[Kite]: No Kite items, returning kernel reply');
       return newKernelReply;
     }
-    console.log('[Kite]: Merging', kernelReply, kiteReply);
+
+    // Dedupe Kernel labels with Kite insertTexts
+    const kiteSet = new Set(kiteReply.items.map(item => item.insertText));
+    newKernelReply.items = newKernelReply.items.filter(
+      item => !kiteSet.has(item.label)
+    );
+
+    console.log('[Kite]: Merging', newKernelReply, kiteReply);
     return {
       ...kiteReply,
       items: kiteReply.items.concat(newKernelReply.items)

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/jl_adapter.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/jl_adapter.ts
@@ -268,13 +268,14 @@ export abstract class JupyterLabWidgetAdapter
 
   async invoke_completer(kind: CompletionTriggerKind) {
     if (this.completion_handler && this.completion_handler.completer.model) {
-      const model = this.completion_handler.completer.model
+      const model = this.completion_handler.completer.model;
       if (model.original) {
         // model.reset(true);
-        const reply = await this.current_completion_connector.fetch()
-        if (model && reply) {
+        this.current_completion_connector.trigger_kind = kind;
+        const reply = await this.current_completion_connector.fetch();
+        if (model && model.setCompletionItems && reply) {
           model.setCompletionItems(reply.items);
-          return
+          return;
         }
       }
     }


### PR DESCRIPTION
Resolves https://github.com/kiteco/kiteco/issues/11188

Adds support for:
- Fetching of kernel completions, both when typing, and when triggering manually
- Creating a timeout only when fetching completions automatically
- De-duping of completions based on `label`
  - There are instances where Kite's insert text contains whitespaces (e.g. `import ` vs. `import` from JLab) 