### PR TITLE
Update readme to be about Kite

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ At a high level, Kite provides you with:
 
 ## Requirements
 
-* JupyterLab v
+* JupyterLab v2.2.0
 * [Kite Engine](https://kite.com/)
 
 Use another editor? Check out [Kite’s other editor integrations](https://kite.com/integrations/).
@@ -40,7 +40,11 @@ When running the Kite Engine for the first time, you'll be guided through a setu
 
 Alternatively, you have 2 options to manually install the extension:
 1. Search for "Kite" in JupyterLab's built-in extension manager and install from there. You may need to enable the Extension Manager under JupyterLab Settings.
-2. Run the command `apm install kite` in your terminal.
+2. Run these commands in your terminal.
+```
+pip install jupyter-kite
+jupyter labextension install @kiteco/jupyterlab-kite
+```
 
 [Learn more about why you should use Kite with JupyterLab.](https://kite.com/integrations/jupyter/)
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The following is a brief guide to using Kite in its default configuration.
 
 When starting JupyterLab with the Kite Assistant for the first time, you'll be guided through a tutorial that shows you how to use Kite.
 
-![tutorial](https://www.dropbox.com/s/ne0iigy5317bk8c/tutorial_file.png?raw=1)
+![tutorial](https://kite.com/kite-public/tutorial_file.png)
 
 This tutorial will only be displayed once. You can show it again at any time by running the command `Kite: Tutorial` from JupyterLab's command palette.
 
@@ -65,14 +65,14 @@ This tutorial will only be displayed once. You can show it again at any time by 
 
 Simply start typing in a saved Python file or Jupyter notebook and Kite will automatically suggest completions for what you're typing. Kite's autocompletions are all labeled with the 🪁 symbol.
 
-![completions](https://www.dropbox.com/s/iiondsnu3hoqg4p/import%20statement.png?raw=1)
+![completions](https://kite.com/kite-public/import_statement.png)
 
 
 ### Completion documentation
 
 Kite's completions come with documentation to help you remember how each completion works.
 
-![Completion docs](https://www.dropbox.com/s/jrvudfklld2ceeq/completion_docs.png?raw=1)
+![Completion docs](https://kite.com/kite-public/completion_docs.png)
 
 
 ### Instant Documentation
@@ -81,26 +81,27 @@ Kite can show you documentation for the symbols in your code in the separate Cop
 
 To do so, open Kite's Copilot (visit the URL kite://home in your browser), ensure that the button labeled "Click for docs to follow cursor" in the upper right corner is enabled, and then simply position your cursor over a symbol.
 
-![Copilot](https://www.dropbox.com/s/tk4b7pkfotge1go/copilot_small.png?raw=1)
+![Copilot](https://kite.com/kite-public/copilot_small.png)
 
 
 ### Commands
 
 Kite comes with sevaral commands that you can run from JupyterLab's command palette.
 
-![commands](https://github.com/kiteco/atom-plugin/blob/master/docs/images/commands.png?raw=true)
+![commands](https://kite.com/kite-public/commands.png)
 
 |Command|Description|
 |:---|:---|
-|`kite:open-copilot`|Open the Copilot|
-|`kite:engine-settings`|Open the settings for the Kite Engine|
-|`kite:tutorial`|Open the Kite tutorial file|
-|`kite:help`|Open Kite's help website in the browser|
+|`Kite: Open Copilot`|Open the Copilot|
+|`Kite: Engine Settings`|Open the settings for the Kite Engine|
+|`Kite: Tutorial`|Open the Kite tutorial file|
+|`Kite: Help`|Open Kite's help website in the browser|
+|`Kite: Toggle Docs Panel`|Toggle the docs panel|
 
 
 ## Troubleshooting
 
-Visit our [help docs](https://help.kite.com) for FAQs and troubleshooting support.
+Visit our [help docs](https://help.kite.com/category/138-jupyterlab-plugin) for FAQs and troubleshooting support.
 
 Happy coding!
 

--- a/README.md
+++ b/README.md
@@ -79,11 +79,9 @@ Kite's completions come with documentation to help you remember how each complet
 
 Kite can show you documentation for the symbols in your code in the separate Copilot application. 
 
+To do so, open Kite's Copilot (visit the URL kite://home in your browser), ensure that the button labeled "Click for docs to follow cursor" in the upper right corner is enabled, and then simply position your cursor over a symbol.
+
 ![Copilot](https://www.dropbox.com/s/tk4b7pkfotge1go/copilot_small.png?raw=1)
-
-To do so, open Kite's Copilot, ensure that the button labeled "Click for docs to follow cursor" in the upper right corner is enabled, and then simply position your cursor over a symbol.
-
-To open Kite's Copilot, visit the URL kite://home in your browser.
 
 
 ### Commands

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ At a high level, Kite provides you with:
 
 ## Requirements
 
-* JupyterLab v2.2.0
+* JupyterLab v2.2.0 and above
 * [Kite Engine](https://kite.com/)
 
 Use another editor? Check out [Kite’s other editor integrations](https://kite.com/integrations/).

--- a/README.md
+++ b/README.md
@@ -1,227 +1,112 @@
-# Language Server Protocol integration for Jupyter(Lab)
+# Kite Autocomplete Extension for JupyterLab
 
-[![Build Status](https://travis-ci.org/krassowski/jupyterlab-lsp.svg?branch=master)](https://travis-ci.org/krassowski/jupyterlab-lsp) [![Build Status](https://dev.azure.com/krassowskimichal/jupyterlab-lsp/_apis/build/status/jupyterlab-lsp?branchName=master)](https://dev.azure.com/krassowskimichal/jupyterlab-lsp/_build/latest?definitionId=1&branchName=master) [![Documentation Status](https://readthedocs.org/projects/jupyterlab-lsp/badge/?version=latest)](https://jupyterlab-lsp.readthedocs.io/en/latest/?badge=latest) [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/krassowski/jupyterlab-lsp/master?urlpath=lab%2Ftree%2Fexamples%2FPython.ipynb)
+Kite is an AI-powered programming assistant that helps you write Python code inside JupyterLab. Kite helps you write code faster by saving you keystrokes and showing you the right information at the right time. Learn more about how Kite boosts your JupyterLab editor's capabilities at https://kite.com/integrations/jupyter/. 
 
-> _This project is still maturing, but you are welcome to check it out, leave feedback and/or a PR_
+At a high level, Kite provides you with:
+* 🧠 __[Line-of-Code Completions](https://kite.com/blog/product/launching-line-of-code-completions-going-cloudless-and-17-million-in-funding/)__ powered by machine learning models trained on the entire open source code universe
+* 🔍 __[Instant documentation](https://kite.com/copilot/)__ for the symbol underneath your cursor so you save time searching for Python docs
 
-Quick Links: **[Installation](#installation) | [Configuring](./docs/Configuring.ipynb) | [Updating](#updating) | [Changelog](./CHANGELOG.md) | [Roadmap](./docs/Roadmap.ipynb) | [Contributing](./CONTRIBUTING.md) | [Extending](./docs/Extending.ipynb)**
 
-## Features
+## Requirements
 
-> Examples show Python code, but most features also work in R, bash, typescript, and [many other languages][language-servers].
+* JupyterLab v
+* [Kite Engine](https://kite.com/)
 
-### Hover
-
-Hover over any piece of code; if an underline appears, you can press <kbd>Ctrl</kbd>
-to get a tooltip with function/class signature, module documentation or any other
-piece of information that the language server provides
-
-![hover](https://raw.githubusercontent.com/krassowski/jupyterlab-lsp/master/examples/screenshots/hover.png)
-
-### Diagnostics
-
-Critical errors have red underline, warnings are orange, etc. Hover
-over the underlined code to see a more detailed message
-
-![inspections](https://raw.githubusercontent.com/krassowski/jupyterlab-lsp/master/examples/screenshots/inspections.png)
-
-### Jump to Definition
-
-Use the context menu entries to jump to definitions
-
-![jump](https://raw.githubusercontent.com/krassowski/jupyterlab-lsp/master/examples/screenshots/jump_to_definition.png)
-
-### Highlight References
-
-Place your cursor on a variable, function, etc and all the usages will be highlighted
-
-### Automatic Completion
-
-Certain characters, for example '.' (dot) in Python, will automatically trigger
-completion
-
-![invoke](https://raw.githubusercontent.com/krassowski/jupyterlab-lsp/master/examples/screenshots/auto_invoke.png)
-
-### Automatic Signature Suggestions
-
-Function signatures will automatically be displayed
-
-![signature](https://raw.githubusercontent.com/krassowski/jupyterlab-lsp/master/examples/screenshots/signature.png)
-
-### Kernel-less Autocompletion
-
-Advanced static-analysis autocompletion without a running kernel
-
-![autocompletion](https://raw.githubusercontent.com/krassowski/jupyterlab-lsp/master/examples/screenshots/autocompletion.png)
-
-> When a kernel is available the suggestions from the kernel (such as keys of a
-> dict and columns of a DataFrame autocompletion) are merged with the suggestions
-> from the Language Server (currently only in notebook).
-
-### Rename
-
-Rename variables, functions and more, in both: notebooks and the file editor.
-Use the context menu option or the <kbd>F2</kbd> shortcut to invoke.
-
-![rename](https://raw.githubusercontent.com/krassowski/jupyterlab-lsp/master/examples/screenshots/rename.png)
-
-### Diagnostics panel
-
-Sort and jump between the diagnostics using the diagnostics panel.
-Open it searching for "Show diagnostics panel" in JupyterLab commands palette or from the context menu.
-
-![panel](https://raw.githubusercontent.com/krassowski/jupyterlab-lsp/master/examples/screenshots/panel.png)
-
-## Prerequisites
-
-Either:
-
-- JupyterLab >=2,<2.1
-
-And:
-
-- Python 3.5+
-- nodejs 10+
+Use another editor? Check out [Kite’s other editor integrations](https://kite.com/integrations/).
 
 ## Installation
 
-> For more extensive installation instructions, see the [documentation][installation-documentation].
+### Installing the Kite Engine
 
-For the current stable version, the following steps are recommended.
-Use of a python `virtualenv` or a conda env is also recommended.
+The [Kite Engine](https://kite.com/) needs to be installed in order for the extension to work properly. The extension itself provides the frontend that interfaces with the Kite Engine, which performs all the code analysis and machine learning 100% locally on your computer (no code is sent to a cloud server).
 
-1. install python 3
+__macOS Instructions__
+1. Download the [installer](https://kite.com/download) and open the downloaded `.dmg` file.
+2. Drag the Kite icon into the `Applications` folder.
+3. Run `Kite.app` to start the Kite Engine.
 
-   ```bash
-   conda install -c conda-forge python=3
-   ```
+__Windows Instructions__
+1. Download the [installer](https://kite.com/download) and run the downloaded `.exe` file.
+2. The installer should run the Kite Engine automatically after installation is complete.
 
-1. install JupyterLab
+__Linux Instructions__
+1. Visit https://kite.com/linux/ to install Kite.
+2. The installer should run the Kite Engine automatically after installation is complete.
 
-   ```bash
-   conda install -c conda-forge 'jupyterlab>=2,<2.1.0a0'
-   # or
-   pip install 'jupyterlab>=2,<2.1.0a0'
-   ```
 
-1. install the server extension:
+### Installing the Kite Extension for JupyterLab
 
-   ```bash
-   pip install jupyter-lsp
-   ```
+When running the Kite Engine for the first time, you'll be guided through a setup process which will allow you to install the JupyterLab extension. You can also install or uninstall the Jupyter extension at any time using the Kite Engine's [plugin manager](https://help.kite.com/article/62-managing-editor-plugins).
 
-1. install `nodejs`
+Alternatively, you have 2 options to manually install the extension:
+1. Search for "Kite" in JupyterLab's built-in extension manager and install from there. You may need to enable the Extension Manager under JupyterLab Settings.
+2. Run the command `apm install kite` in your terminal.
 
-   ```bash
-   conda install -c conda-forge nodejs
-   # or one of the following, as an administrator
-   choco install nodejs            # Windows with Chocolatey
-   sudo apt-get install nodejs     # Debian/Ubuntu
-   sudo brew install nodejs        # MacOS with Homebrew
-   sudo dnf install nodejs         # Fedora
-   sudo yum install nodejs         # RHEL/CentOS
-   ```
+[Learn more about why you should use Kite with JupyterLab.](https://kite.com/integrations/jupyter/)
 
-1. install the frontend extension:
 
-   ```bash
-   jupyter labextension install @krassowski/jupyterlab-lsp           # for JupyterLab 2.x
-   # jupyter labextension install @krassowski/jupyterlab-lsp@0.8.0   # for JupyterLab 1.x
-   ```
+## Usage
 
-1. install LSP servers for languages of your choice; for example, for Python
-   ([pyls](https://github.com/palantir/python-language-server)) and
-   R ([languageserver](https://github.com/REditorSupport/languageserver)) servers:
+The following is a brief guide to using Kite in its default configuration.
 
-   ```bash
-   pip install python-language-server[all]
-   R -e 'install.packages("languageserver")'
-   ```
+### Tutorial
 
-   or from `conda-forge`
+When starting JupyterLab with the Kite Assistant for the first time, you'll be guided through a tutorial that shows you how to use Kite.
 
-   ```bash
-   conda install -c conda-forge python-language-server r-languageserver
-   ```
+![tutorial](https://github.com/kiteco/atom-plugin/blob/master/docs/images/tutorial.png?raw=true)
 
-   Please see our full list of
-   [supported language servers][language-servers]
-   which includes installation hints for the common package managers (npm/pip/conda).
-   In general, any LSP server from the
-   [Microsoft list](https://microsoft.github.io/language-server-protocol/implementors/servers/)
-   should work after [some additional configuration](./CONTRIBUTING.md#specs).
+This tutorial will only be displayed once. You can show it again at any time by running the command `Kite: Tutorial` from JupyterLab's command palette.
 
-   Note: it is worth visiting the repository of each server you install as
-   many provide additional configuration options.
+### Autocompletions
 
-   Note on pyls (python-language-server) issues: pyls is known to require specific
-   versions of some dependencies such as [ujson <= 1.35](https://github.com/krassowski/jupyterlab-lsp/issues/203#issuecomment-599039556), [jedi == 0.15.2 and parso == 0.5.2](https://github.com/krassowski/jupyterlab-lsp/issues/200#issuecomment-599039353). If you experience any issues with LSP functions in Python,
-   please check if you have the right version using `pip freeze` command.
+Simply start typing in a saved Python file or Jupyter notebook and Kite will automatically suggest completions for what you're typing. Kite's autocompletions are all labeled with the `⟠` symbol.
 
-1. (Optional, Linux/OSX-only) to enable opening files outside of the root
-   directory (the place where you start JupyterLab), create `.lsp_symlink` and
-   symlink your `/home`, or any other location which includes the files that you
-   wish to make possible to open in there:
+![completions](https://github.com/kiteco/atom-plugin/blob/master/docs/images/completions.png?raw=true)
 
-   ```bash
-   mkdir .lsp_symlink
-   cd .lsp_symlink
-   ln -s /home home
-   ```
 
-   If your user does not have sufficient permissions to traverse the entire path,
-   you will not be able to open the file. A more detailed guide on symlinking
-   (written for a related jupyterlab-go-to-definition extension) is available
-   [here](https://github.com/krassowski/jupyterlab-go-to-definition/blob/master/README.md#which-directories-to-symlink).
+### Function documentation
 
-### Updating
+When you're calling a function, Kite will show you the function's documentation to help you remember what arguments you need to pass in.
 
-To update previously installed extensions:
+![Function docs](https://www.dropbox.com/s/d4sxqf0i3ymhxrk/function_docs.png?raw=1)
 
-```bash
-pip install -U jupyter-lsp
-jupyter labextension update @krassowski/jupyterlab-lsp
-```
 
-### Getting the latest alpha/beta/RC version
+### Instant Documentation
 
-Use `install` command (update does not seem to work) appending `@<0.x.y.rc-z>` to the
-extension name, like this:
+Kite can show you documentation for the symbols in your code in the Copilot application. To do so, open Kite's Copilot, ensure that the button labeled "Click for docs to follow cursor" in the upper right corner is enabled, and then simply position your cursor over a symbol.
 
-```bash
-jupyter labextension install @krassowski/jupyterlab-lsp@0.7.0-rc.0
-```
+![copilot](https://github.com/kiteco/atom-plugin/blob/master/docs/images/copilot.png?raw=true)
 
-### Configuring the servers
 
-We plan to provide a configuration GUI at some time ([#25](https://github.com/krassowski/jupyterlab-lsp/issues/25)), but in the meantime, you can use the instructions for the specific servers as described on their websites (see the [table of language servers][language-servers] for links).
+### Commands
 
-#### I want to hide specific diagnostics/inspections/warnings
+Kite comes with sevaral commands that you can run from JupyterLab's command palette.
 
-For example, the Python server that we support by default ([pyls](https://github.com/palantir/python-language-server)) has a [configuration section](https://github.com/palantir/python-language-server#configuration) in their documentation which refers to the providers of specific features, including `pycodestyle` for inspections/diagnostics.
+![commands](https://github.com/kiteco/atom-plugin/blob/master/docs/images/commands.png?raw=true)
 
-The exact configuration details will vary between operating systems (please see the [configuration section of pycodestyle documentation](https://pycodestyle.readthedocs.io/en/latest/intro.html#configuration)), but as an example, on Linux you would simply need to create a file called `~/.config/pycodestyle`, which may look like that:
+|Command|Description|
+|:---|:---|
+|`kite:open-copilot`|Open the Copilot|
+|`kite:engine-settings`|Open the settings for the Kite Engine|
+|`kite:tutorial`|Open the Kite tutorial file|
+|`kite:help`|Open Kite's help website in the browser|
 
-```cfg
-[pycodestyle]
-ignore = E402, E703
-max-line-length = 120
-```
 
-In the example above:
+## Troubleshooting
 
-- ignoring E402 allows imports which are not on the very top of the file,
-- ignoring E703 allows terminating semicolon (useful for matplotlib plots),
-- the maximal allowed line length is increased to 120.
+Visit our [help docs](https://help.kite.com) for FAQs and troubleshooting support.
 
-After changing the configuration you may need to restart the JupyterLab, and please be advised that the errors in configuration may prevent the servers from functioning properly.
+Happy coding!
 
-Again, please do check the pycodestyle documentation for specific error codes, and check the configuration of other feature providers and language servers as needed.
 
-## Acknowledgements
+---
 
-This would not be possible without the fantastic initial work at
-[wylieconlon/lsp-editor-adapter](https://github.com/wylieconlon/lsp-editor-adapter).
+#### About Kite 
 
-[language-servers]: https://jupyterlab-lsp.readthedocs.io/en/latest/Language%20Servers.html
-[installation-documentation]: https://jupyterlab-lsp.readthedocs.io/en/latest/Installation.html
+Kite is built by a team in San Francisco devoted to making programming easier and more enjoyable for all. Follow Kite on
+[Twitter](https://twitter.com/kitehq) and get the latest news and programming tips on the
+[Kite Blog](https://kite.com/blog).
+Kite has been featured in [Wired](https://www.wired.com/2016/04/kites-coding-asssitant-spots-errors-finds-better-open-source/), 
+[VentureBeat](https://venturebeat.com/2019/01/28/kite-raises-17-million-for-its-ai-powered-developer-environment/), 
+[The Next Web](https://thenextweb.com/dd/2016/04/14/kite-plugin/), and 
+[TechCrunch](https://techcrunch.com/2019/01/28/kite-raises-17m-for-its-ai-driven-code-completion-tool/). 

--- a/README.md
+++ b/README.md
@@ -57,29 +57,33 @@ The following is a brief guide to using Kite in its default configuration.
 
 When starting JupyterLab with the Kite Assistant for the first time, you'll be guided through a tutorial that shows you how to use Kite.
 
-![tutorial](https://github.com/kiteco/atom-plugin/blob/master/docs/images/tutorial.png?raw=true)
+![tutorial](https://www.dropbox.com/s/ne0iigy5317bk8c/tutorial_file.png?raw=1)
 
 This tutorial will only be displayed once. You can show it again at any time by running the command `Kite: Tutorial` from JupyterLab's command palette.
 
 ### Autocompletions
 
-Simply start typing in a saved Python file or Jupyter notebook and Kite will automatically suggest completions for what you're typing. Kite's autocompletions are all labeled with the `⟠` symbol.
+Simply start typing in a saved Python file or Jupyter notebook and Kite will automatically suggest completions for what you're typing. Kite's autocompletions are all labeled with the 🪁 symbol.
 
-![completions](https://github.com/kiteco/atom-plugin/blob/master/docs/images/completions.png?raw=true)
+![completions](https://www.dropbox.com/s/iiondsnu3hoqg4p/import%20statement.png?raw=1)
 
 
-### Function documentation
+### Completion documentation
 
-When you're calling a function, Kite will show you the function's documentation to help you remember what arguments you need to pass in.
+Kite's completions come with documentation to help you remember how each completion works.
 
-![Function docs](https://www.dropbox.com/s/d4sxqf0i3ymhxrk/function_docs.png?raw=1)
+![Completion docs](https://www.dropbox.com/s/jrvudfklld2ceeq/completion_docs.png?raw=1)
 
 
 ### Instant Documentation
 
-Kite can show you documentation for the symbols in your code in the Copilot application. To do so, open Kite's Copilot, ensure that the button labeled "Click for docs to follow cursor" in the upper right corner is enabled, and then simply position your cursor over a symbol.
+Kite can show you documentation for the symbols in your code in the separate Copilot application. 
 
-![copilot](https://github.com/kiteco/atom-plugin/blob/master/docs/images/copilot.png?raw=true)
+![Copilot](https://www.dropbox.com/s/tk4b7pkfotge1go/copilot_small.png?raw=1)
+
+To do so, open Kite's Copilot, ensure that the button labeled "Click for docs to follow cursor" in the upper right corner is enabled, and then simply position your cursor over a symbol.
+
+To open Kite's Copilot, visit the URL kite://home in your browser.
 
 
 ### Commands

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ To do so, open Kite's Copilot (visit the URL kite://home in your browser), ensur
 
 ### Commands
 
-Kite comes with sevaral commands that you can run from JupyterLab's command palette.
+Kite comes with several commands that you can run from JupyterLab's command palette.
 
 ![commands](https://kite.com/kite-public/commands.png)
 


### PR DESCRIPTION
Updated to be similar to [Atom plugin's readme](https://github.com/kiteco/atom-plugin/blob/master/README.md).

### Work to be done:

- [x] Add min. JLab version
- [x] Confirm: Will extension manager be enabled by default when this release is out?
- [x] Troubleshooting steps for manual installation → what command to run
- [x] Change section header to "completion documentation"
- [x] Switch screenshots to the ones hosted in this repo

Add updated screenshots for:
- [x] Tutorial 
- [x] Autocompletions
- [x] Function documentation
- [x] Command Palette
