### PR TITLE
Reset query when force-fetching completions

### DIFF
--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/jl_adapter.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/jl_adapter.ts
@@ -274,6 +274,7 @@ export abstract class JupyterLabWidgetAdapter
         this.current_completion_connector.trigger_kind = kind;
         const reply = await this.current_completion_connector.fetch();
         if (model && model.setCompletionItems && reply) {
+          model.query = '';
           model.setCompletionItems(reply.items);
           return;
         }


### PR DESCRIPTION
Resolves https://github.com/kiteco/kiteco/issues/11136

`model.query` is what core uses internally to filter completions. Hence, we reset its value to `''` to prevent our completions from being filtered out.