### PR TITLE
Reset model on cursor change

### DIFF
--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/KiteModel.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/KiteModel.ts
@@ -1,0 +1,39 @@
+import { Completer, CompleterModel } from '@jupyterlab/completer';
+
+export class KiteModel extends CompleterModel {
+  private _state: Completer.ITextState | undefined;
+
+  constructor() {
+    super();
+  }
+
+  get state(): Completer.ITextState | undefined {
+    return this._state;
+  }
+
+  set state(newState: Completer.ITextState) {
+    this._state = newState;
+  }
+
+  handleCursorChange(change: Completer.ITextState) {
+    super.handleCursorChange(change);
+    const prevState = this.state;
+    if (prevState) {
+      /**
+       * Reset model unless cursor change is result of typing a new character.
+       */
+      if (
+        change.column - prevState.column === 1 ||
+        (change.line - prevState.line === 1 && change.column === 1)
+      ) {
+        return;
+      }
+      this.reset(true);
+    }
+  }
+
+  handleTextChange(change: Completer.ITextState) {
+    super.handleTextChange(change);
+    this.state = change;
+  }
+}

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/file_editor.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/file_editor.ts
@@ -11,6 +11,7 @@ import { KiteConnector } from './components/completion';
 import { CodeEditor } from '@jupyterlab/codeeditor';
 import { VirtualFileEditor } from '../../virtual/editors/file_editor';
 import { DocumentConnectionManager } from '../../connection_manager';
+import { KiteModel } from './KiteModel';
 
 export class FileEditorAdapter extends JupyterLabWidgetAdapter {
   editor: FileEditor;
@@ -95,6 +96,7 @@ export class FileEditorAdapter extends JupyterLabWidgetAdapter {
     });
     if (handler instanceof CompletionHandler) {
       this.completion_handler = handler;
+      this.completion_handler.completer.model = new KiteModel();
     }
   }
 

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/notebook.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/notebook.ts
@@ -17,6 +17,7 @@ import ILanguageInfoMetadata = nbformat.ILanguageInfoMetadata;
 import { DocumentConnectionManager } from '../../connection_manager';
 import { Session } from '@jupyterlab/services';
 import { SessionContext } from '@jupyterlab/apputils';
+import { KiteModel } from './KiteModel';
 
 export class NotebookAdapter extends JupyterLabWidgetAdapter {
   editor: Notebook;
@@ -195,6 +196,7 @@ export class NotebookAdapter extends JupyterLabWidgetAdapter {
     this.current_completion_handler = handler;
     if (handler instanceof CompletionHandler) {
       this.completion_handler = handler;
+      this.completion_handler.completer.model = new KiteModel();
     }
     this.widget.content.activeCellChanged.connect(this.on_completions, this);
   }


### PR DESCRIPTION
Resolves https://github.com/kiteco/kiteco/issues/11277

- Adds extension of `CompleterModel`
- Record state on `handleTextChange`
- Compare states on `handleCursorChange`. If it's determined that the cursor has changed without a text change, reset the model.