### PR TITLE
Allow Toggling Of Docs

### DIFF
--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/file_editor.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/file_editor.ts
@@ -1,16 +1,17 @@
-import { JupyterLabWidgetAdapter } from './jl_adapter';
-import { FileEditor } from '@jupyterlab/fileeditor';
+import { JupyterFrontEnd } from '@jupyterlab/application';
+import { CodeEditor } from '@jupyterlab/codeeditor';
+import { CodeMirrorEditor } from '@jupyterlab/codemirror';
+import { CompletionHandler, ICompletionManager } from '@jupyterlab/completer';
 import { IDocumentWidget } from '@jupyterlab/docregistry';
+import { FileEditor } from '@jupyterlab/fileeditor';
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { FileEditorJumper } from '@krassowski/jupyterlab_go_to_definition/lib/jumpers/fileeditor';
 import * as CodeMirror from 'codemirror';
-import { JupyterFrontEnd } from '@jupyterlab/application';
-import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
-import { CodeMirrorEditor } from '@jupyterlab/codemirror';
-import { ICompletionManager, CompletionHandler } from '@jupyterlab/completer';
-import { KiteConnector } from './components/completion';
-import { CodeEditor } from '@jupyterlab/codeeditor';
-import { VirtualFileEditor } from '../../virtual/editors/file_editor';
 import { DocumentConnectionManager } from '../../connection_manager';
+import { VirtualFileEditor } from '../../virtual/editors/file_editor';
+import { KiteConnector } from './components/completion';
+import { JupyterLabWidgetAdapter } from './jl_adapter';
+import { KiteCompleter } from './kite_completer';
 import { KiteModel } from './kite_model';
 
 export class FileEditorAdapter extends JupyterLabWidgetAdapter {
@@ -96,7 +97,18 @@ export class FileEditorAdapter extends JupyterLabWidgetAdapter {
     });
     if (handler instanceof CompletionHandler) {
       this.completion_handler = handler;
-      this.completion_handler.completer.model = new KiteModel();
+      const kiteModel = new KiteModel();
+      this.completion_handler.completer.model = kiteModel;
+      const kiteCompleter = new KiteCompleter({
+        editor: this.editor.editor,
+        model: kiteModel
+      });
+      try {
+        (this.completion_handler.completer as KiteCompleter).handleEvent =
+          kiteCompleter.handleEvent;
+      } catch {
+        // no-op
+      }
     }
   }
 

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/file_editor.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/file_editor.ts
@@ -104,8 +104,9 @@ export class FileEditorAdapter extends JupyterLabWidgetAdapter {
         model: kiteModel
       });
       try {
-        (this.completion_handler.completer as KiteCompleter).handleEvent =
-          kiteCompleter.handleEvent;
+        const jlCompleter = this.completion_handler.completer as KiteCompleter;
+        jlCompleter.onUpdateRequest = kiteCompleter.onUpdateRequest;
+        jlCompleter.handleEvent = kiteCompleter.handleEvent;
       } catch {
         // no-op
       }

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/kite_completer.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/kite_completer.ts
@@ -1,0 +1,20 @@
+import { Completer } from '@jupyterlab/completer';
+
+export class KiteCompleter extends Completer {
+  handleEvent(event: Event): void {
+    if (this.isHidden || !this.editor) {
+      return;
+    }
+    if (event.type === 'keydown') {
+      const keydownEvt = event as KeyboardEvent;
+      if (keydownEvt.shiftKey && keydownEvt.keyCode === 9) {
+        event.preventDefault();
+        event.stopPropagation();
+        event.stopImmediatePropagation();
+        console.log('Success!');
+        return;
+      }
+    }
+    super.handleEvent(event);
+  }
+}

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/kite_completer.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/kite_completer.ts
@@ -1,20 +1,52 @@
 import { Completer } from '@jupyterlab/completer';
+import { Message } from '@lumino/messaging';
 
+/**
+ * CompletionHandler's Completer property is readonly,
+ * so while we can extend its protected methods,
+ * "this" will still be bound to the base class.
+ */
 export class KiteCompleter extends Completer {
+  private static SHOULD_SHOW_DOCS = true;
+
+  onUpdateRequest(msg: Message) {
+    super.onUpdateRequest(msg);
+    if (!KiteCompleter.SHOULD_SHOW_DOCS) {
+      // Toggle classNames to correct state on subsequent updates.
+      toggle(this.node, KiteCompleter.SHOULD_SHOW_DOCS);
+    }
+  }
+
   handleEvent(event: Event): void {
     if (this.isHidden || !this.editor) {
       return;
     }
     if (event.type === 'keydown') {
       const keydownEvt = event as KeyboardEvent;
+      // Shift + Tab
       if (keydownEvt.shiftKey && keydownEvt.keyCode === 9) {
         event.preventDefault();
         event.stopPropagation();
         event.stopImmediatePropagation();
-        console.log('Success!');
+        KiteCompleter.SHOULD_SHOW_DOCS = !KiteCompleter.SHOULD_SHOW_DOCS;
+        // Toggle docs immediately.
+        toggle(this.node, KiteCompleter.SHOULD_SHOW_DOCS);
         return;
       }
     }
     super.handleEvent(event);
+  }
+}
+
+export function toggle(node: HTMLElement, shouldShow: boolean) {
+  const docpanels = node.querySelectorAll('.jp-Completer-docpanel');
+  if (shouldShow) {
+    docpanels.forEach(docpanel => {
+      docpanel.classList.remove('hidden');
+    });
+  } else {
+    docpanels.forEach(docpanel => {
+      docpanel.classList.add('hidden');
+    });
   }
 }

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/notebook.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/notebook.ts
@@ -185,6 +185,7 @@ export class NotebookAdapter extends JupyterLabWidgetAdapter {
   connect_completion() {
     // see https://github.com/jupyterlab/jupyterlab/blob/c0e9eb94668832d1208ad3b00a9791ef181eca4c/packages/completer-extension/src/index.ts#L198-L213
     const cell = this.widget.content.activeCell;
+    console.log('Connecting Completion Notebook');
     if (cell == null) {
       return;
     }
@@ -204,8 +205,9 @@ export class NotebookAdapter extends JupyterLabWidgetAdapter {
         model: kiteModel
       });
       try {
-        (this.completion_handler.completer as KiteCompleter).handleEvent =
-          kiteCompleter.handleEvent;
+        const jlCompleter = this.completion_handler.completer as KiteCompleter;
+        jlCompleter.onUpdateRequest = kiteCompleter.onUpdateRequest;
+        jlCompleter.handleEvent = kiteCompleter.handleEvent;
       } catch {
         // no-op
       }

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/notebook.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/notebook.ts
@@ -1,23 +1,24 @@
-import { JupyterLabWidgetAdapter } from './jl_adapter';
-import { Notebook, NotebookPanel } from '@jupyterlab/notebook';
-import * as CodeMirror from 'codemirror';
-import { VirtualEditorForNotebook } from '../../virtual/editors/notebook';
-import { ICompletionManager, CompletionHandler } from '@jupyterlab/completer';
-import { NotebookJumper } from '@krassowski/jupyterlab_go_to_definition/lib/jumpers/notebook';
-import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { JupyterFrontEnd } from '@jupyterlab/application';
-import { until_ready } from '../../utils';
-import { KiteConnector } from './components/completion';
-import { CodeEditor } from '@jupyterlab/codeeditor';
-import { language_specific_overrides } from '../../magics/defaults';
-import { foreign_code_extractors } from '../../extractors/defaults';
-import { Cell } from '@jupyterlab/cells';
-import * as nbformat from '@jupyterlab/nbformat';
-import ILanguageInfoMetadata = nbformat.ILanguageInfoMetadata;
-import { DocumentConnectionManager } from '../../connection_manager';
-import { Session } from '@jupyterlab/services';
 import { SessionContext } from '@jupyterlab/apputils';
+import { Cell } from '@jupyterlab/cells';
+import { CodeEditor } from '@jupyterlab/codeeditor';
+import { CompletionHandler, ICompletionManager } from '@jupyterlab/completer';
+import * as nbformat from '@jupyterlab/nbformat';
+import { Notebook, NotebookPanel } from '@jupyterlab/notebook';
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+import { Session } from '@jupyterlab/services';
+import { NotebookJumper } from '@krassowski/jupyterlab_go_to_definition/lib/jumpers/notebook';
+import * as CodeMirror from 'codemirror';
+import { DocumentConnectionManager } from '../../connection_manager';
+import { foreign_code_extractors } from '../../extractors/defaults';
+import { language_specific_overrides } from '../../magics/defaults';
+import { until_ready } from '../../utils';
+import { VirtualEditorForNotebook } from '../../virtual/editors/notebook';
+import { KiteConnector } from './components/completion';
+import { JupyterLabWidgetAdapter } from './jl_adapter';
+import { KiteCompleter } from './kite_completer';
 import { KiteModel } from './kite_model';
+import ILanguageInfoMetadata = nbformat.ILanguageInfoMetadata;
 
 export class NotebookAdapter extends JupyterLabWidgetAdapter {
   editor: Notebook;
@@ -196,7 +197,18 @@ export class NotebookAdapter extends JupyterLabWidgetAdapter {
     this.current_completion_handler = handler;
     if (handler instanceof CompletionHandler) {
       this.completion_handler = handler;
-      this.completion_handler.completer.model = new KiteModel();
+      const kiteModel = new KiteModel();
+      this.completion_handler.completer.model = kiteModel;
+      const kiteCompleter = new KiteCompleter({
+        editor: cell.editor,
+        model: kiteModel
+      });
+      try {
+        (this.completion_handler.completer as KiteCompleter).handleEvent =
+          kiteCompleter.handleEvent;
+      } catch {
+        // no-op
+      }
     }
     this.widget.content.activeCellChanged.connect(this.on_completions, this);
   }

--- a/packages/jupyterlab-kite/style/index.css
+++ b/packages/jupyterlab-kite/style/index.css
@@ -2,5 +2,8 @@
 @import url('./logo.css');
 
 .jp-Completer-docpanel {
-    overflow: auto;
+  overflow: auto;
+}
+.jp-Completer-docpanel.hidden {
+  display: none;
 }


### PR DESCRIPTION
Resolves https://github.com/kiteco/kiteco/issues/11179

Persisting the user's setting if JupyterLab is refreshed or restarted is not in scope for this PR.

- Adds `KiteCompleter` class which overrides `handleEvent` and `onUpdateRequest`. 
- `handleEvent` intercepts shift+tab if the completions list is visible, toggles `SHOULD_SHOW_DOCS`, then toggles the docs panel.
- `onUpdateRequest` will toggle the docs off if `SHOULD_SHOW_DOCS` is false.
- Added CSS to enable hiding of docs.

This would probably be much cleaner to do with a core change :\