### PR TITLE
Trim completions with large replacement ranges

### DIFF
--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
@@ -220,6 +220,19 @@ export class KiteConnector extends DataConnector<
     let all_non_prefixed = true;
     let items: CompletionHandler.ICompletionItem[] = [];
     (lspCompletionItems as KiteCompletionItem[]).forEach(match => {
+      if (token.type === 'string') {
+        let text = match.insertText ? match.insertText : match.label;
+        let quote = token.value.charAt(0); // Currently doesn't address triple-quoted strings
+        let fragments = text.split(quote);
+        if (fragments.length === 2 || fragments.length === 3) {
+          // Strip out the completion prefix (area before the string)
+          // and, if present, the suffix
+          // e.g. ['foo'] -> foo
+          //      ['bar -> bar
+          match.insertText = fragments[1];
+        }
+      }
+
       let completionItem = {
         label: match.label,
         insertText: match.insertText,

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
@@ -231,6 +231,15 @@ export class KiteConnector extends DataConnector<
         let preToken = lineText.substring(range.start.character, start.ch);
         if (insertion.startsWith(preToken)) {
           insertion = insertion.substring(preToken.length);
+        } else {
+          // This completion will be inserted malformed, and so we will dispose of it
+          console.log(
+            '[Kite][Completer] Disposing of un-insertable completion: ' +
+              match.insertText
+              ? match.insertText
+              : match.label
+          );
+          return;
         }
       }
       if (range.end.character > cursor.ch) {
@@ -241,6 +250,15 @@ export class KiteConnector extends DataConnector<
             0,
             insertion.length - postCursor.length
           );
+        } else {
+          // This completion will be inserted malformed, and so we will dispose of it
+          console.log(
+            '[Kite][Completer] Disposing of un-insertable completion: ' +
+              match.insertText
+              ? match.insertText
+              : match.label
+          );
+          return;
         }
       }
       if (insertion !== match.insertText) {


### PR DESCRIPTION
Resolves kiteco/kiteco#11159

Previously, kited would return completions that replaced more than the string token, which doesn't work when there are other completions that expect to only be replacing the string token.