### PR TITLE
Only fetch kernel completions after alphabetical characters or . ' "

### DIFF
--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
@@ -184,13 +184,13 @@ export class KiteConnector extends DataConnector<
          * - No kernel connector
          * - No request object
          * - Token type is string (otherwise kernel completions appear within docstrings)
-         * - Preceding character isn't a kernel trigger character
+         * - Preceding character isn't a kernel trigger character (unless request is manual)
          */
         if (
           !this._kernel_connector ||
           !request ||
           should_suppress_strings ||
-          !kernelTriggerRegex.test(typed_character)
+          !(kernelTriggerRegex.test(typed_character) || isManual)
         ) {
           return KiteConnector.EmptyIReply;
         }

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
@@ -174,9 +174,9 @@ export class KiteConnector extends DataConnector<
       const should_suppress_strings = !isManual && token.type === 'string';
 
       /**
-       * Kernel completions should only be fetched after an alphanumeric character or . ' "
+       * Kernel completions should only be fetched after an alphabetical character or . ' "
        */
-      const kernelTriggerRegex = /^[0-9a-zA-Z\.\'\"]+/;
+      const kernelTriggerRegex = /^[a-zA-Z\.\'\"]+/;
 
       const kernelPromise = () => {
         /**

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
@@ -165,6 +165,7 @@ export class KiteConnector extends DataConnector<
       };
 
       const isManual = this._trigger_kind === CompletionTriggerKind.Invoked;
+
       /**
        * """
        * """
@@ -172,14 +173,25 @@ export class KiteConnector extends DataConnector<
        */
       const should_suppress_strings = !isManual && token.type === 'string';
 
+      /**
+       * Kernel completions should only be fetched after an alphanumeric character or . ' "
+       */
+      const kernelTriggerRegex = /^[0-9a-zA-Z\.\'\"]+/;
+
       const kernelPromise = () => {
         /**
          * Don't fetch kernel completions if:
          * - No kernel connector
          * - No request object
          * - Token type is string (otherwise kernel completions appear within docstrings)
+         * - Preceding character isn't a kernel trigger character
          */
-        if (!this._kernel_connector || !request || should_suppress_strings) {
+        if (
+          !this._kernel_connector ||
+          !request ||
+          should_suppress_strings ||
+          !kernelTriggerRegex.test(typed_character)
+        ) {
           return KiteConnector.EmptyIReply;
         }
         return this._kernel_connector.fetch(request).catch(() => {


### PR DESCRIPTION
Fixes https://github.com/kiteco/kiteco/issues/11450