### PR TITLE
fix completer race

### DIFF
--- a/packages/jupyterlab-kite/src/adapters/codemirror/cm_adapter.ts
+++ b/packages/jupyterlab-kite/src/adapters/codemirror/cm_adapter.ts
@@ -67,6 +67,7 @@ export class CodeMirrorAdapter {
 
       if (!change || !change.text.length || !change.text[0].length) {
         // deletion - ignore
+        // TODO(naman) this should probably be handled by the individual features for more flexibility
         return true;
       }
 

--- a/packages/jupyterlab-kite/src/adapters/codemirror/testutils.ts
+++ b/packages/jupyterlab-kite/src/adapters/codemirror/testutils.ts
@@ -105,6 +105,7 @@ export abstract class FeatureTestEnvironment
 
   public create_dummy_components(): IJupyterLabComponentsManager {
     return {
+      cancel_completer: () => void {},
       invoke_completer: () => {
         // nothing yet
       },

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
@@ -27,417 +27,458 @@ interface KiteCompletionItem extends CompletionItem {
 }
 
 export class KiteConnector extends DataConnector<
-  CompletionHandler.ICompletionItemsReply,
-  void,
-  CompletionHandler.IRequest
-> {
-  isDisposed = false;
-  private _editor: CodeEditor.IEditor;
-  private _kernel_connector: KernelConnector;
-  private _connections: Map<VirtualDocument.id_path, LSPConnection>;
-  protected options: KiteConnector.IOptions;
+         CompletionHandler.ICompletionItemsReply,
+         void,
+         CompletionHandler.IRequest
+       > {
+         isDisposed = false;
+         private _editor: CodeEditor.IEditor;
+         private _kernel_connector: KernelConnector;
+         private _connections: Map<VirtualDocument.id_path, LSPConnection>;
+         protected options: KiteConnector.IOptions;
 
-  private fetchAbort: AbortController;
+         private fetchAbort: AbortController;
 
-  virtual_editor: VirtualEditor;
-  responseType = CompletionHandler.ICompletionItemsResponseType;
-  private _trigger_kind: CompletionTriggerKind = CompletionTriggerKind.Invoked;
-  private suppress_auto_invoke_in = ['comment'];
-  private icon: LabIcon = new LabIcon({
-    name: 'jupyterlab-kite:completion-icon',
-    svgstr: kiteLogo
-  });
+         virtual_editor: VirtualEditor;
+         responseType = CompletionHandler.ICompletionItemsResponseType;
+         private _trigger_kind: CompletionTriggerKind =
+           CompletionTriggerKind.Invoked;
+         private suppress_auto_invoke_in = ['comment'];
+         private icon: LabIcon = new LabIcon({
+           name: 'jupyterlab-kite:completion-icon',
+           svgstr: kiteLogo
+         });
 
-  /**
-   * Create a new Kite connector for completion requests.
-   *
-   * @param options - The instantiation options for the Kite connector.
-   */
-  constructor(options: KiteConnector.IOptions) {
-    super();
-    this._editor = options.editor;
-    this._connections = options.connections;
-    this.virtual_editor = options.virtual_editor;
-    this.options = options;
+         /**
+          * Create a new Kite connector for completion requests.
+          *
+          * @param options - The instantiation options for the Kite connector.
+          */
+         constructor(options: KiteConnector.IOptions) {
+           super();
+           this._editor = options.editor;
+           this._connections = options.connections;
+           this.virtual_editor = options.virtual_editor;
+           this.options = options;
 
-    this.fetchAbort = new AbortController();
+           this.fetchAbort = new AbortController();
 
-    if (options.session) {
-      this._kernel_connector = new KernelConnector({
-        session: options.session
-      });
-    }
+           if (options.session) {
+             this._kernel_connector = new KernelConnector({
+               session: options.session
+             });
+           }
 
-    this.icon.bindprops({ className: 'kite-logo' });
-  }
+           this.icon.bindprops({ className: 'kite-logo' });
+         }
 
-  dispose() {
-    if (this.isDisposed) {
-      return;
-    }
-    delete this._connections;
-    delete this._kernel_connector;
-    delete this.virtual_editor;
-    delete this.options;
-    delete this._editor;
-    delete this.icon;
-    delete this.isDisposed;
-    delete this.fetchAbort;
-  }
+         dispose() {
+           if (this.isDisposed) {
+             return;
+           }
+           delete this._connections;
+           delete this._kernel_connector;
+           delete this.virtual_editor;
+           delete this.options;
+           delete this._editor;
+           delete this.icon;
+           delete this.isDisposed;
+           delete this.fetchAbort;
+         }
 
-  /**
-   * Fetch completion requests.
-   *
-   * @param request - The completion request text and details.
-   */
-  fetch(
-    request?: CompletionHandler.IRequest
-  ): Promise<CompletionHandler.ICompletionItemsReply | undefined> {
-    return new Promise(async (resolve, reject) => {
-      this.fetchAbort.abort();
-      this.fetchAbort = new AbortController();
-      this.fetchAbort.signal.addEventListener(
-        'abort',
-        () => {
-          resolve(KiteConnector.EmptyICompletionItemsReply);
-        },
-        { once: true }
-      );
-      let editor = this._editor;
+         abort(): void {
+           this.fetchAbort.abort();
+         }
 
-      const cursor = editor.getCursorPosition();
-      const token = editor.getTokenForPosition(cursor);
+         /**
+          * Fetch completion requests.
+          *
+          * @param request - The completion request text and details.
+          */
+         fetch(
+           request?: CompletionHandler.IRequest
+         ): Promise<CompletionHandler.ICompletionItemsReply | undefined> {
+           return new Promise(async (resolve, reject) => {
+             const fetchAbort = new AbortController();
 
-      if (
-        token.type &&
-        this.suppress_auto_invoke_in.indexOf(token.type) !== -1
-      ) {
-        console.log(
-          '[Kite][Completer] Suppressing completer auto-invoke in',
-          token.type
-        );
-        return;
-      }
+             this.fetchAbort.abort();
+             this.fetchAbort = fetchAbort;
 
-      const start = editor.getPositionAt(token.offset);
-      const end = editor.getPositionAt(token.offset + token.value.length);
+             fetchAbort.signal.addEventListener(
+               'abort',
+               () => {
+                 resolve(KiteConnector.EmptyICompletionItemsReply);
+               },
+               { once: true }
+             );
+             let editor = this._editor;
 
-      if (!start || !end) {
-        console.log('[Kite][Completer] No start or end position found');
-        resolve(KiteConnector.EmptyICompletionItemsReply);
-        return;
-      }
+             const cursor = editor.getCursorPosition();
+             const token = editor.getTokenForPosition(cursor);
 
-      let position_in_token = cursor.column - start.column - 1;
-      const typed_character = token.value[cursor.column - start.column - 1];
+             if (
+               token.type &&
+               this.suppress_auto_invoke_in.indexOf(token.type) !== -1
+             ) {
+               console.log(
+                 '[Kite][Completer] Suppressing completer auto-invoke in',
+                 token.type
+               );
+               return;
+             }
 
-      let start_in_root = this.transform_from_editor_to_root(start);
-      let end_in_root = this.transform_from_editor_to_root(end);
-      let cursor_in_root = this.transform_from_editor_to_root(cursor);
+             const start = editor.getPositionAt(token.offset);
+             const end = editor.getPositionAt(
+               token.offset + token.value.length
+             );
 
-      let virtual_editor = this.virtual_editor;
+             if (!start || !end) {
+               console.log('[Kite][Completer] No start or end position found');
+               resolve(KiteConnector.EmptyICompletionItemsReply);
+               return;
+             }
 
-      // find document for position
-      let document = virtual_editor.document_at_root_position(start_in_root);
+             let position_in_token = cursor.column - start.column - 1;
+             const typed_character =
+               token.value[cursor.column - start.column - 1];
 
-      let virtual_start = virtual_editor.root_position_to_virtual_position(
-        start_in_root
-      );
-      let virtual_end = virtual_editor.root_position_to_virtual_position(
-        end_in_root
-      );
-      let virtual_cursor = virtual_editor.root_position_to_virtual_position(
-        cursor_in_root
-      );
+             let start_in_root = this.transform_from_editor_to_root(start);
+             let end_in_root = this.transform_from_editor_to_root(end);
+             let cursor_in_root = this.transform_from_editor_to_root(cursor);
 
-      const kitePromise = () => {
-        return this.fetch_kite(
-          token,
-          typed_character,
-          virtual_start,
-          virtual_end,
-          virtual_cursor,
-          document,
-          position_in_token
-        ).catch(() => {
-          return KiteConnector.EmptyICompletionItemsReply;
-        });
-      };
+             let virtual_editor = this.virtual_editor;
 
-      const isManual = this._trigger_kind === CompletionTriggerKind.Invoked;
-      /**
-       * """
-       * """
-       * has token.type string, so we suppress auto fetching.
-       */
-      const should_suppress_strings = !isManual && token.type === 'string';
+             // find document for position
+             let document = virtual_editor.document_at_root_position(
+               start_in_root
+             );
 
-      const kernelPromise = () => {
-        /**
-         * Don't fetch kernel completions if:
-         * - No kernel connector
-         * - No request object
-         * - Token type is string (otherwise kernel completions appear within docstrings)
-         */
-        if (!this._kernel_connector || !request || should_suppress_strings) {
-          return KiteConnector.EmptyIReply;
-        }
-        return this._kernel_connector.fetch(request).catch(() => {
-          return KiteConnector.EmptyIReply;
-        });
-      };
+             let virtual_start = virtual_editor.root_position_to_virtual_position(
+               start_in_root
+             );
+             let virtual_end = virtual_editor.root_position_to_virtual_position(
+               end_in_root
+             );
+             let virtual_cursor = virtual_editor.root_position_to_virtual_position(
+               cursor_in_root
+             );
 
-      const timeout = new Promise<CompletionHandler.IReply>(resolve => {
-        setTimeout(resolve, 500, KiteConnector.EmptyIReply);
-      });
-      const kernelTimeoutPromise = () => {
-        return Promise.race([timeout, kernelPromise()]).then(reply => {
-          return reply;
-        });
-      };
+             const kitePromise = () => {
+               return this.fetch_kite(
+                 token,
+                 typed_character,
+                 virtual_start,
+                 virtual_end,
+                 virtual_cursor,
+                 document,
+                 position_in_token
+               ).catch(() => {
+                 return KiteConnector.EmptyICompletionItemsReply;
+               });
+             };
 
-      const [kernel, kite] = await Promise.all([
-        isManual ? kernelPromise() : kernelTimeoutPromise(),
-        kitePromise()
-      ]);
-      resolve(this.merge_replies(kernel, kite));
-    });
-  }
+             const isManual =
+               this._trigger_kind === CompletionTriggerKind.Invoked;
+             /**
+              * """
+              * """
+              * has token.type string, so we suppress auto fetching.
+              */
+             const should_suppress_strings =
+               !isManual && token.type === 'string';
 
-  async fetch_kite(
-    token: CodeEditor.IToken,
-    typed_character: string,
-    start: IVirtualPosition,
-    end: IVirtualPosition,
-    cursor: IVirtualPosition,
-    document: VirtualDocument,
-    position_in_token: number
-  ): Promise<CompletionHandler.ICompletionItemsReply> {
-    let connection = this._connections.get(document.id_path);
+             const kernelPromise = () => {
+               /**;
+                * Don't fetch kernel completions if:
+                * - No kernel connector
+                * - No request object
+                * - Token type is string (otherwise kernel completions appear within docstrings)
+                */
+               if (
+                 !this._kernel_connector ||
+                 !request ||
+                 should_suppress_strings
+               ) {
+                 return KiteConnector.EmptyIReply;
+               }
+               return this._kernel_connector.fetch(request).catch(() => {
+                 return KiteConnector.EmptyIReply;
+               });
+             };
 
-    if (!connection) {
-      console.log('[Kite][Completer] No LSP Connection found');
-      return KiteConnector.EmptyICompletionItemsReply;
-    }
+             const kernelTimeoutPromise = () => {
+               const timeout = new Promise<CompletionHandler.IReply>(
+                 resolve => {
+                   setTimeout(resolve, 500, KiteConnector.EmptyIReply);
+                 }
+               );
+               return Promise.race([timeout, kernelPromise()]);
+             };
 
-    const lspCompletionItems = await connection
-      .getCompletion(
-        cursor,
-        {
-          start,
-          end,
-          text: token.value
-        },
-        document.document_info,
-        false,
-        typed_character,
-        this.trigger_kind
-      )
-      .catch(err => console.error(err));
+             const [kernel, kite] = await Promise.all([
+               isManual ? kernelPromise() : kernelTimeoutPromise(),
+               kitePromise()
+             ]);
+             const merged = this.merge_replies(kernel, kite);
 
-    console.log('[Kite][Completer] Fetched', lspCompletionItems);
+             if (fetchAbort.signal.aborted) {
+               // will eventually resolve to empty via the registered handler
+               return;
+             }
+             resolve(merged);
+           });
+         }
 
-    let prefix = token.value.slice(0, position_in_token + 1);
-    let all_non_prefixed = true;
-    let items: CompletionHandler.ICompletionItem[] = [];
-    let lineText = document
-      .get_editor_at_virtual_line(cursor)
-      .getLineTokens(cursor.line)
-      .map(token => token.string)
-      .join('');
-    (lspCompletionItems as KiteCompletionItem[]).forEach(match => {
-      let range = match.textEdit.range;
-      let insertion = match.insertText ? match.insertText : match.label;
-      if (range.start.character < start.ch) {
-        // If this completion begins before the given token begins,
-        // we need to trim it so that it begins within the given token instead.
-        let preToken = lineText.substring(range.start.character, start.ch);
-        if (insertion.startsWith(preToken)) {
-          // We can trim this completion because the trimmed portion will match the existing text in the line.
-          insertion = insertion.substring(preToken.length);
-        } else {
-          // We can't trim the beginning of this completion.
-          console.log(
-            '[Kite][Completer] Disposing of un-insertable completion: %s',
-            match.insertText ? match.insertText : match.label
-          );
-          return;
-        }
-      } else if (range.start.character > start.ch + 1) {
-        // The start of the completion can be 1 character past the start of the token,
-        // to accommodate completions after single character tokens like '.' or ' '.
-        // Completions that start further than that fall outside of the standard insertion range.
-        console.log(
-          '[Kite][Completer] Disposing of un-insertable completion: %s',
-          match.insertText ? match.insertText : match.label
-        );
-        return;
-      }
-      if (range.end.character > cursor.ch) {
-        // If the completion goes past the cursor, it is either a type-through completion,
-        // or it modifies characters past the cursor. However, the standard insertion range
-        // only extends past the cursor if all the completions are type-through, so no completions
-        // that modify characters past the cursor are insertable.
-        let postCursor = lineText.substring(cursor.ch, range.end.character);
-        if (insertion.endsWith(postCursor)) {
-          // This will result in the cursor being placed before what the user perceives
-          // as a type-through, instead of after it, which is not ideal.
-          insertion = insertion.substring(
-            0,
-            insertion.length - postCursor.length
-          );
-        } else {
-          // This completion modifies characters past the cursor, so it's un-insertable.
-          console.log(
-            '[Kite][Completer] Disposing of un-insertable completion: %s',
-            match.insertText ? match.insertText : match.label
-          );
-          return;
-        }
-      } else if (range.end.character < cursor.ch) {
-        // The end of the standard completion range will not be before the cursor.
-        // It is either on the cursor, or after it (in a type-through case).
-        // Therefore any completion that ends before the cursor cannot be inserted.
-        console.log(
-          '[Kite][Completer] Disposing of un-insertable completion: %s',
-          match.insertText ? match.insertText : match.label
-        );
-        return;
-      }
-      if (insertion !== match.insertText) {
-        console.log(
-          '[Kite][Completer] Trimmed %s => %s',
-          match.insertText,
-          insertion
-        );
-        match.insertText = insertion;
-      }
+         async fetch_kite(
+           token: CodeEditor.IToken,
+           typed_character: string,
+           start: IVirtualPosition,
+           end: IVirtualPosition,
+           cursor: IVirtualPosition,
+           document: VirtualDocument,
+           position_in_token: number
+         ): Promise<CompletionHandler.ICompletionItemsReply> {
+           let connection = this._connections.get(document.id_path);
 
-      let completionItem = {
-        label: match.label,
-        insertText: match.insertText,
-        type: match.hint
-          ? match.hint
-          : match.kind
-          ? completionItemKindNames[match.kind]
-          : '',
-        icon: this.icon,
-        documentation: MarkupContent.is(match.documentation)
-          ? match.documentation.value
-          : match.documentation,
-        filterText: match.filterText,
-        deprecated: match.deprecated
-      };
+           if (!connection) {
+             console.log('[Kite][Completer] No LSP Connection found');
+             return KiteConnector.EmptyICompletionItemsReply;
+           }
 
-      // Update prefix values
-      let text = match.insertText ? match.insertText : match.label;
-      if (text.toLowerCase().startsWith(prefix.toLowerCase())) {
-        all_non_prefixed = false;
-        if (prefix !== token.value) {
-          if (text.toLowerCase().startsWith(token.value.toLowerCase())) {
-            // given a completion insert text "display_table" and two test cases:
-            // disp<tab>data →  display_table<cursor>data
-            // disp<tab>lay  →  display_table<cursor>
-            // we have to adjust the prefix for the latter (otherwise we would get display_table<cursor>lay),
-            // as we are constrained NOT to replace after the prefix (which would be "disp" otherwise)
-            prefix = token.value;
-          }
-        }
-      }
+           const lspCompletionItems = await connection
+             .getCompletion(
+               cursor,
+               {
+                 start,
+                 end,
+                 text: token.value
+               },
+               document.document_info,
+               false,
+               typed_character,
+               this.trigger_kind
+             )
+             .catch(err => console.error(err));
 
-      items.push(completionItem);
-    });
+           console.log('[Kite][Completer] Fetched', lspCompletionItems);
 
-    return {
-      // note in the ContextCompleter it was:
-      // start: token.offset,
-      // end: token.offset + token.value.length,
-      // which does not work with "from statistics import <tab>" as the last token ends at "t" of "import",
-      // so the completer would append "mean" as "from statistics importmean" (without space!);
-      // (in such a case the typedCharacters is undefined as we are out of range)
-      // a different workaround would be to prepend the token.value prefix:
-      // text = token.value + text;
-      // but it did not work for "from statistics <tab>" and lead to "from statisticsimport" (no space)
-      start: token.offset + (all_non_prefixed ? 1 : 0),
-      end: token.offset + prefix.length,
-      items
-    };
-  }
+           let prefix = token.value.slice(0, position_in_token + 1);
+           let all_non_prefixed = true;
+           let items: CompletionHandler.ICompletionItem[] = [];
+           let lineText = document
+             .get_editor_at_virtual_line(cursor)
+             .getLineTokens(cursor.line)
+             .map(token => token.string)
+             .join('');
+           (lspCompletionItems as KiteCompletionItem[]).forEach(match => {
+             let range = match.textEdit.range;
+             let insertion = match.insertText ? match.insertText : match.label;
+             if (range.start.character < start.ch) {
+               // If this completion begins before the given token begins,
+               // we need to trim it so that it begins within the given token instead.
+               let preToken = lineText.substring(
+                 range.start.character,
+                 start.ch
+               );
+               if (insertion.startsWith(preToken)) {
+                 // We can trim this completion because the trimmed portion will match the existing text in the line.
+                 insertion = insertion.substring(preToken.length);
+               } else {
+                 // We can't trim the beginning of this completion.
+                 console.log(
+                   '[Kite][Completer] Disposing of un-insertable completion: %s',
+                   match.insertText ? match.insertText : match.label
+                 );
+                 return;
+               }
+             } else if (range.start.character > start.ch + 1) {
+               // The start of the completion can be 1 character past the start of the token,
+               // to accommodate completions after single character tokens like '.' or ' '.
+               // Completions that start further than that fall outside of the standard insertion range.
+               console.log(
+                 '[Kite][Completer] Disposing of un-insertable completion: %s',
+                 match.insertText ? match.insertText : match.label
+               );
+               return;
+             }
+             if (range.end.character > cursor.ch) {
+               // If the completion goes past the cursor, it is either a type-through completion,
+               // or it modifies characters past the cursor. However, the standard insertion range
+               // only extends past the cursor if all the completions are type-through, so no completions
+               // that modify characters past the cursor are insertable.
+               let postCursor = lineText.substring(
+                 cursor.ch,
+                 range.end.character
+               );
+               if (insertion.endsWith(postCursor)) {
+                 // This will result in the cursor being placed before what the user perceives
+                 // as a type-through, instead of after it, which is not ideal.
+                 insertion = insertion.substring(
+                   0,
+                   insertion.length - postCursor.length
+                 );
+               } else {
+                 // This completion modifies characters past the cursor, so it's un-insertable.
+                 console.log(
+                   '[Kite][Completer] Disposing of un-insertable completion: %s',
+                   match.insertText ? match.insertText : match.label
+                 );
+                 return;
+               }
+             } else if (range.end.character < cursor.ch) {
+               // The end of the standard completion range will not be before the cursor.
+               // It is either on the cursor, or after it (in a type-through case).
+               // Therefore any completion that ends before the cursor cannot be inserted.
+               console.log(
+                 '[Kite][Completer] Disposing of un-insertable completion: %s',
+                 match.insertText ? match.insertText : match.label
+               );
+               return;
+             }
+             if (insertion !== match.insertText) {
+               console.log(
+                 '[Kite][Completer] Trimmed %s => %s',
+                 match.insertText,
+                 insertion
+               );
+               match.insertText = insertion;
+             }
 
-  private merge_replies(
-    kernelReply: CompletionHandler.IReply,
-    kiteReply: CompletionHandler.ICompletionItemsReply
-  ): CompletionHandler.ICompletionItemsReply {
-    const newKernelReply = this.transform(kernelReply);
-    if (!newKernelReply.items.length) {
-      return kiteReply;
-    }
-    if (!kiteReply.items.length) {
-      return newKernelReply;
-    }
+             let completionItem = {
+               label: match.label,
+               insertText: match.insertText,
+               type: match.hint
+                 ? match.hint
+                 : match.kind
+                 ? completionItemKindNames[match.kind]
+                 : '',
+               icon: this.icon,
+               documentation: MarkupContent.is(match.documentation)
+                 ? match.documentation.value
+                 : match.documentation,
+               filterText: match.filterText,
+               deprecated: match.deprecated
+             };
 
-    // Dedupe Kite and Kernel items based on label
-    const kiteSet = new Set(kiteReply.items.map(item => item.label));
-    newKernelReply.items = newKernelReply.items.filter(
-      item => !kiteSet.has(item.label)
-    );
+             // Update prefix values
+             let text = match.insertText ? match.insertText : match.label;
+             if (text.toLowerCase().startsWith(prefix.toLowerCase())) {
+               all_non_prefixed = false;
+               if (prefix !== token.value) {
+                 if (text.toLowerCase().startsWith(token.value.toLowerCase())) {
+                   // given a completion insert text "display_table" and two test cases:
+                   // disp<tab>data →  display_table<cursor>data
+                   // disp<tab>lay  →  display_table<cursor>
+                   // we have to adjust the prefix for the latter (otherwise we would get display_table<cursor>lay),
+                   // as we are constrained NOT to replace after the prefix (which would be "disp" otherwise)
+                   prefix = token.value;
+                 }
+               }
+             }
 
-    console.log('[Kite]: Merging', kiteReply, newKernelReply);
-    return {
-      ...kiteReply,
-      items: kiteReply.items.concat(newKernelReply.items)
-    };
-  }
+             items.push(completionItem);
+           });
 
-  /**
-   * Converts an IReply into an ICompletionItemsReply.
-   */
-  private transform(
-    reply: CompletionHandler.IReply
-  ): CompletionHandler.ICompletionItemsReply {
-    const items = new Array<CompletionHandler.ICompletionItem>();
-    const metadata = reply.metadata || {};
-    const types = metadata._jupyter_types_experimental as JSONArray;
+           return {
+             // note in the ContextCompleter it was:
+             // start: token.offset,
+             // end: token.offset + token.value.length,
+             // which does not work with "from statistics import <tab>" as the last token ends at "t" of "import",
+             // so the completer would append "mean" as "from statistics importmean" (without space!);
+             // (in such a case the typedCharacters is undefined as we are out of range)
+             // a different workaround would be to prepend the token.value prefix:
+             // text = token.value + text;
+             // but it did not work for "from statistics <tab>" and lead to "from statisticsimport" (no space)
+             start: token.offset + (all_non_prefixed ? 1 : 0),
+             end: token.offset + prefix.length,
+             items
+           };
+         }
 
-    if (types) {
-      types.forEach((item: JSONObject) => {
-        const text = item.text as string;
-        const type = item.type as string;
-        items.push({ label: text, type: type === '<unknown>' ? '' : type });
-      });
-    } else {
-      const matches = reply.matches;
-      matches.forEach(match => {
-        items.push({ label: match });
-      });
-    }
-    return { start: reply.start, end: reply.end, items };
-  }
+         private merge_replies(
+           kernelReply: CompletionHandler.IReply,
+           kiteReply: CompletionHandler.ICompletionItemsReply
+         ): CompletionHandler.ICompletionItemsReply {
+           const newKernelReply = this.transform(kernelReply);
+           if (!newKernelReply.items.length) {
+             return kiteReply;
+           }
+           if (!kiteReply.items.length) {
+             return newKernelReply;
+           }
 
-  transform_from_editor_to_root(position: CodeEditor.IPosition): IRootPosition {
-    let cm_editor = (this._editor as CodeMirrorEditor).editor;
-    let cm_start = PositionConverter.ce_to_cm(position) as IEditorPosition;
-    return this.virtual_editor.transform_editor_to_root(cm_editor, cm_start);
-  }
+           // Dedupe Kite and Kernel items based on label
+           const kiteSet = new Set(kiteReply.items.map(item => item.label));
+           newKernelReply.items = newKernelReply.items.filter(
+             item => !kiteSet.has(item.label)
+           );
 
-  get trigger_kind(): CompletionTriggerKind {
-    return this._trigger_kind;
-  }
+           console.log('[Kite]: Merging', kiteReply, newKernelReply);
+           return {
+             ...kiteReply,
+             items: kiteReply.items.concat(newKernelReply.items)
+           };
+         }
 
-  set trigger_kind(kind: CompletionTriggerKind) {
-    this._trigger_kind = kind;
-  }
+         /**
+          * Converts an IReply into an ICompletionItemsReply.
+          */
+         private transform(
+           reply: CompletionHandler.IReply
+         ): CompletionHandler.ICompletionItemsReply {
+           const items = new Array<CompletionHandler.ICompletionItem>();
+           const metadata = reply.metadata || {};
+           const types = metadata._jupyter_types_experimental as JSONArray;
 
-  with_trigger_kind(kind: CompletionTriggerKind, fn: Function) {
-    try {
-      this.trigger_kind = kind;
-      return fn();
-    } finally {
-      // Return to the default state
-      this.trigger_kind = CompletionTriggerKind.Invoked;
-    }
-  }
-}
+           if (types) {
+             types.forEach((item: JSONObject) => {
+               const text = item.text as string;
+               const type = item.type as string;
+               items.push({
+                 label: text,
+                 type: type === '<unknown>' ? '' : type
+               });
+             });
+           } else {
+             const matches = reply.matches;
+             matches.forEach(match => {
+               items.push({ label: match });
+             });
+           }
+           return { start: reply.start, end: reply.end, items };
+         }
+
+         transform_from_editor_to_root(
+           position: CodeEditor.IPosition
+         ): IRootPosition {
+           let cm_editor = (this._editor as CodeMirrorEditor).editor;
+           let cm_start = PositionConverter.ce_to_cm(
+             position
+           ) as IEditorPosition;
+           return this.virtual_editor.transform_editor_to_root(
+             cm_editor,
+             cm_start
+           );
+         }
+
+         get trigger_kind(): CompletionTriggerKind {
+           return this._trigger_kind;
+         }
+
+         set trigger_kind(kind: CompletionTriggerKind) {
+           this._trigger_kind = kind;
+         }
+
+         with_trigger_kind(kind: CompletionTriggerKind, fn: Function) {
+           try {
+             this.trigger_kind = kind;
+             return fn();
+           } finally {
+             // Return to the default state
+             this.trigger_kind = CompletionTriggerKind.Invoked;
+           }
+         }
+       }
 
 /**
  * A namespace for Kite connector statics.

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
@@ -27,458 +27,426 @@ interface KiteCompletionItem extends CompletionItem {
 }
 
 export class KiteConnector extends DataConnector<
-         CompletionHandler.ICompletionItemsReply,
-         void,
-         CompletionHandler.IRequest
-       > {
-         isDisposed = false;
-         private _editor: CodeEditor.IEditor;
-         private _kernel_connector: KernelConnector;
-         private _connections: Map<VirtualDocument.id_path, LSPConnection>;
-         protected options: KiteConnector.IOptions;
+  CompletionHandler.ICompletionItemsReply,
+  void,
+  CompletionHandler.IRequest
+> {
+  isDisposed = false;
+  private _editor: CodeEditor.IEditor;
+  private _kernel_connector: KernelConnector;
+  private _connections: Map<VirtualDocument.id_path, LSPConnection>;
+  protected options: KiteConnector.IOptions;
 
-         private fetchAbort: AbortController;
+  private fetchAbort: AbortController;
 
-         virtual_editor: VirtualEditor;
-         responseType = CompletionHandler.ICompletionItemsResponseType;
-         private _trigger_kind: CompletionTriggerKind =
-           CompletionTriggerKind.Invoked;
-         private suppress_auto_invoke_in = ['comment'];
-         private icon: LabIcon = new LabIcon({
-           name: 'jupyterlab-kite:completion-icon',
-           svgstr: kiteLogo
-         });
+  virtual_editor: VirtualEditor;
+  responseType = CompletionHandler.ICompletionItemsResponseType;
+  private _trigger_kind: CompletionTriggerKind = CompletionTriggerKind.Invoked;
+  private suppress_auto_invoke_in = ['comment'];
+  private icon: LabIcon = new LabIcon({
+    name: 'jupyterlab-kite:completion-icon',
+    svgstr: kiteLogo
+  });
 
-         /**
-          * Create a new Kite connector for completion requests.
-          *
-          * @param options - The instantiation options for the Kite connector.
-          */
-         constructor(options: KiteConnector.IOptions) {
-           super();
-           this._editor = options.editor;
-           this._connections = options.connections;
-           this.virtual_editor = options.virtual_editor;
-           this.options = options;
+  /**
+   * Create a new Kite connector for completion requests.
+   *
+   * @param options - The instantiation options for the Kite connector.
+   */
+  constructor(options: KiteConnector.IOptions) {
+    super();
+    this._editor = options.editor;
+    this._connections = options.connections;
+    this.virtual_editor = options.virtual_editor;
+    this.options = options;
 
-           this.fetchAbort = new AbortController();
+    this.fetchAbort = new AbortController();
 
-           if (options.session) {
-             this._kernel_connector = new KernelConnector({
-               session: options.session
-             });
-           }
+    if (options.session) {
+      this._kernel_connector = new KernelConnector({
+        session: options.session
+      });
+    }
 
-           this.icon.bindprops({ className: 'kite-logo' });
-         }
+    this.icon.bindprops({ className: 'kite-logo' });
+  }
 
-         dispose() {
-           if (this.isDisposed) {
-             return;
-           }
-           delete this._connections;
-           delete this._kernel_connector;
-           delete this.virtual_editor;
-           delete this.options;
-           delete this._editor;
-           delete this.icon;
-           delete this.isDisposed;
-           delete this.fetchAbort;
-         }
+  dispose() {
+    if (this.isDisposed) {
+      return;
+    }
+    delete this._connections;
+    delete this._kernel_connector;
+    delete this.virtual_editor;
+    delete this.options;
+    delete this._editor;
+    delete this.icon;
+    delete this.isDisposed;
+    delete this.fetchAbort;
+  }
 
-         abort(): void {
-           this.fetchAbort.abort();
-         }
+  abort(): void {
+    this.fetchAbort.abort();
+  }
 
-         /**
-          * Fetch completion requests.
-          *
-          * @param request - The completion request text and details.
-          */
-         fetch(
-           request?: CompletionHandler.IRequest
-         ): Promise<CompletionHandler.ICompletionItemsReply | undefined> {
-           return new Promise(async (resolve, reject) => {
-             const fetchAbort = new AbortController();
+  /**
+   * Fetch completion requests.
+   *
+   * @param request - The completion request text and details.
+   */
+  fetch(
+    request?: CompletionHandler.IRequest
+  ): Promise<CompletionHandler.ICompletionItemsReply | undefined> {
+    return new Promise(async (resolve, reject) => {
+      const fetchAbort = new AbortController();
 
-             this.fetchAbort.abort();
-             this.fetchAbort = fetchAbort;
+      this.fetchAbort.abort();
+      this.fetchAbort = fetchAbort;
 
-             fetchAbort.signal.addEventListener(
-               'abort',
-               () => {
-                 resolve(KiteConnector.EmptyICompletionItemsReply);
-               },
-               { once: true }
-             );
-             let editor = this._editor;
+      fetchAbort.signal.addEventListener(
+        'abort',
+        () => {
+          resolve(KiteConnector.EmptyICompletionItemsReply);
+        },
+        { once: true }
+      );
+      let editor = this._editor;
 
-             const cursor = editor.getCursorPosition();
-             const token = editor.getTokenForPosition(cursor);
+      const cursor = editor.getCursorPosition();
+      const token = editor.getTokenForPosition(cursor);
 
-             if (
-               token.type &&
-               this.suppress_auto_invoke_in.indexOf(token.type) !== -1
-             ) {
-               console.log(
-                 '[Kite][Completer] Suppressing completer auto-invoke in',
-                 token.type
-               );
-               return;
-             }
+      if (
+        token.type &&
+        this.suppress_auto_invoke_in.indexOf(token.type) !== -1
+      ) {
+        console.log(
+          '[Kite][Completer] Suppressing completer auto-invoke in',
+          token.type
+        );
+        return;
+      }
 
-             const start = editor.getPositionAt(token.offset);
-             const end = editor.getPositionAt(
-               token.offset + token.value.length
-             );
+      const start = editor.getPositionAt(token.offset);
+      const end = editor.getPositionAt(token.offset + token.value.length);
 
-             if (!start || !end) {
-               console.log('[Kite][Completer] No start or end position found');
-               resolve(KiteConnector.EmptyICompletionItemsReply);
-               return;
-             }
+      if (!start || !end) {
+        console.log('[Kite][Completer] No start or end position found');
+        resolve(KiteConnector.EmptyICompletionItemsReply);
+        return;
+      }
 
-             let position_in_token = cursor.column - start.column - 1;
-             const typed_character =
-               token.value[cursor.column - start.column - 1];
+      let position_in_token = cursor.column - start.column - 1;
+      const typed_character = token.value[cursor.column - start.column - 1];
 
-             let start_in_root = this.transform_from_editor_to_root(start);
-             let end_in_root = this.transform_from_editor_to_root(end);
-             let cursor_in_root = this.transform_from_editor_to_root(cursor);
+      let start_in_root = this.transform_from_editor_to_root(start);
+      let end_in_root = this.transform_from_editor_to_root(end);
+      let cursor_in_root = this.transform_from_editor_to_root(cursor);
 
-             let virtual_editor = this.virtual_editor;
+      let virtual_editor = this.virtual_editor;
 
-             // find document for position
-             let document = virtual_editor.document_at_root_position(
-               start_in_root
-             );
+      // find document for position
+      let document = virtual_editor.document_at_root_position(start_in_root);
 
-             let virtual_start = virtual_editor.root_position_to_virtual_position(
-               start_in_root
-             );
-             let virtual_end = virtual_editor.root_position_to_virtual_position(
-               end_in_root
-             );
-             let virtual_cursor = virtual_editor.root_position_to_virtual_position(
-               cursor_in_root
-             );
+      let virtual_start = virtual_editor.root_position_to_virtual_position(start_in_root);
+      let virtual_end = virtual_editor.root_position_to_virtual_position(end_in_root);
+      let virtual_cursor = virtual_editor.root_position_to_virtual_position(cursor_in_root);
 
-             const kitePromise = () => {
-               return this.fetch_kite(
-                 token,
-                 typed_character,
-                 virtual_start,
-                 virtual_end,
-                 virtual_cursor,
-                 document,
-                 position_in_token
-               ).catch(() => {
-                 return KiteConnector.EmptyICompletionItemsReply;
-               });
-             };
+      const kitePromise = async () => {
+        try {
+          return await this.fetch_kite(
+            token,
+            typed_character,
+            virtual_start,
+            virtual_end,
+            virtual_cursor,
+            document,
+            position_in_token
+          )
+        } catch {
+          return KiteConnector.EmptyICompletionItemsReply;
+        };
+      };
 
-             const isManual =
-               this._trigger_kind === CompletionTriggerKind.Invoked;
-             /**
-              * """
-              * """
-              * has token.type string, so we suppress auto fetching.
-              */
-             const should_suppress_strings =
-               !isManual && token.type === 'string';
+      const isManual = this._trigger_kind === CompletionTriggerKind.Invoked;
+      /**
+       * """
+       * """
+       * has token.type string, so we suppress auto fetching.
+       */
+      const should_suppress_strings = !isManual && token.type === 'string';
 
-             const kernelPromise = () => {
-               /**;
-                * Don't fetch kernel completions if:
-                * - No kernel connector
-                * - No request object
-                * - Token type is string (otherwise kernel completions appear within docstrings)
-                */
-               if (
-                 !this._kernel_connector ||
-                 !request ||
-                 should_suppress_strings
-               ) {
-                 return KiteConnector.EmptyIReply;
-               }
-               return this._kernel_connector.fetch(request).catch(() => {
-                 return KiteConnector.EmptyIReply;
-               });
-             };
+      const kernelPromise = () => {
+        /**
+         * Don't fetch kernel completions if:
+         * - No kernel connector
+         * - No request object
+         * - Token type is string (otherwise kernel completions appear within docstrings)
+         */
+        if (!this._kernel_connector || !request || should_suppress_strings) {
+          return KiteConnector.EmptyIReply;
+        }
+        return this._kernel_connector.fetch(request).catch(() => {
+          return KiteConnector.EmptyIReply;
+        });
+      };
 
-             const kernelTimeoutPromise = () => {
-               const timeout = new Promise<CompletionHandler.IReply>(
-                 resolve => {
-                   setTimeout(resolve, 500, KiteConnector.EmptyIReply);
-                 }
-               );
-               return Promise.race([timeout, kernelPromise()]);
-             };
+      const kernelTimeoutPromise = () => {
+        const timeout = new Promise<CompletionHandler.IReply>(
+          resolve => {
+            setTimeout(resolve, 500, KiteConnector.EmptyIReply);
+          }
+        );
+        return Promise.race([timeout, kernelPromise()]);
+      };
 
-             const [kernel, kite] = await Promise.all([
-               isManual ? kernelPromise() : kernelTimeoutPromise(),
-               kitePromise()
-             ]);
-             const merged = this.merge_replies(kernel, kite);
+      const [kernel, kite] = await Promise.all([
+        isManual ? kernelPromise() : kernelTimeoutPromise(),
+        kitePromise()
+      ]);
+      const merged = this.merge_replies(kernel, kite);
 
-             if (fetchAbort.signal.aborted) {
-               // will eventually resolve to empty via the registered handler
-               return;
-             }
-             resolve(merged);
-           });
-         }
+      if (fetchAbort.signal.aborted) {
+        // will eventually resolve to empty via the registered handler
+        return;
+      }
+      resolve(merged);
+    });
+  }
 
-         async fetch_kite(
-           token: CodeEditor.IToken,
-           typed_character: string,
-           start: IVirtualPosition,
-           end: IVirtualPosition,
-           cursor: IVirtualPosition,
-           document: VirtualDocument,
-           position_in_token: number
-         ): Promise<CompletionHandler.ICompletionItemsReply> {
-           let connection = this._connections.get(document.id_path);
+  async fetch_kite(
+    token: CodeEditor.IToken,
+    typed_character: string,
+    start: IVirtualPosition,
+    end: IVirtualPosition,
+    cursor: IVirtualPosition,
+    document: VirtualDocument,
+    position_in_token: number
+  ): Promise<CompletionHandler.ICompletionItemsReply> {
+    let connection = this._connections.get(document.id_path);
 
-           if (!connection) {
-             console.log('[Kite][Completer] No LSP Connection found');
-             return KiteConnector.EmptyICompletionItemsReply;
-           }
+    if (!connection) {
+      console.log('[Kite][Completer] No LSP Connection found');
+      return KiteConnector.EmptyICompletionItemsReply;
+    }
 
-           const lspCompletionItems = await connection
-             .getCompletion(
-               cursor,
-               {
-                 start,
-                 end,
-                 text: token.value
-               },
-               document.document_info,
-               false,
-               typed_character,
-               this.trigger_kind
-             )
-             .catch(err => console.error(err));
+    const lspCompletionItems = await connection
+      .getCompletion(
+        cursor,
+        {
+          start,
+          end,
+          text: token.value
+        },
+        document.document_info,
+        false,
+        typed_character,
+        this.trigger_kind
+      )
+      .catch(err => console.error(err));
 
-           console.log('[Kite][Completer] Fetched', lspCompletionItems);
+    console.log('[Kite][Completer] Fetched', lspCompletionItems);
 
-           let prefix = token.value.slice(0, position_in_token + 1);
-           let all_non_prefixed = true;
-           let items: CompletionHandler.ICompletionItem[] = [];
-           let lineText = document
-             .get_editor_at_virtual_line(cursor)
-             .getLineTokens(cursor.line)
-             .map(token => token.string)
-             .join('');
-           (lspCompletionItems as KiteCompletionItem[]).forEach(match => {
-             let range = match.textEdit.range;
-             let insertion = match.insertText ? match.insertText : match.label;
-             if (range.start.character < start.ch) {
-               // If this completion begins before the given token begins,
-               // we need to trim it so that it begins within the given token instead.
-               let preToken = lineText.substring(
-                 range.start.character,
-                 start.ch
-               );
-               if (insertion.startsWith(preToken)) {
-                 // We can trim this completion because the trimmed portion will match the existing text in the line.
-                 insertion = insertion.substring(preToken.length);
-               } else {
-                 // We can't trim the beginning of this completion.
-                 console.log(
-                   '[Kite][Completer] Disposing of un-insertable completion: %s',
-                   match.insertText ? match.insertText : match.label
-                 );
-                 return;
-               }
-             } else if (range.start.character > start.ch + 1) {
-               // The start of the completion can be 1 character past the start of the token,
-               // to accommodate completions after single character tokens like '.' or ' '.
-               // Completions that start further than that fall outside of the standard insertion range.
-               console.log(
-                 '[Kite][Completer] Disposing of un-insertable completion: %s',
-                 match.insertText ? match.insertText : match.label
-               );
-               return;
-             }
-             if (range.end.character > cursor.ch) {
-               // If the completion goes past the cursor, it is either a type-through completion,
-               // or it modifies characters past the cursor. However, the standard insertion range
-               // only extends past the cursor if all the completions are type-through, so no completions
-               // that modify characters past the cursor are insertable.
-               let postCursor = lineText.substring(
-                 cursor.ch,
-                 range.end.character
-               );
-               if (insertion.endsWith(postCursor)) {
-                 // This will result in the cursor being placed before what the user perceives
-                 // as a type-through, instead of after it, which is not ideal.
-                 insertion = insertion.substring(
-                   0,
-                   insertion.length - postCursor.length
-                 );
-               } else {
-                 // This completion modifies characters past the cursor, so it's un-insertable.
-                 console.log(
-                   '[Kite][Completer] Disposing of un-insertable completion: %s',
-                   match.insertText ? match.insertText : match.label
-                 );
-                 return;
-               }
-             } else if (range.end.character < cursor.ch) {
-               // The end of the standard completion range will not be before the cursor.
-               // It is either on the cursor, or after it (in a type-through case).
-               // Therefore any completion that ends before the cursor cannot be inserted.
-               console.log(
-                 '[Kite][Completer] Disposing of un-insertable completion: %s',
-                 match.insertText ? match.insertText : match.label
-               );
-               return;
-             }
-             if (insertion !== match.insertText) {
-               console.log(
-                 '[Kite][Completer] Trimmed %s => %s',
-                 match.insertText,
-                 insertion
-               );
-               match.insertText = insertion;
-             }
+    let prefix = token.value.slice(0, position_in_token + 1);
+    let all_non_prefixed = true;
+    let items: CompletionHandler.ICompletionItem[] = [];
+    let lineText = document
+      .get_editor_at_virtual_line(cursor)
+      .getLineTokens(cursor.line)
+      .map(token => token.string)
+      .join('');
+    (lspCompletionItems as KiteCompletionItem[]).forEach(match => {
+      let range = match.textEdit.range;
+      let insertion = match.insertText ? match.insertText : match.label;
+      if (range.start.character < start.ch) {
+        // If this completion begins before the given token begins,
+        // we need to trim it so that it begins within the given token instead.
+        let preToken = lineText.substring(range.start.character, start.ch);
+        if (insertion.startsWith(preToken)) {
+          // We can trim this completion because the trimmed portion will match the existing text in the line.
+          insertion = insertion.substring(preToken.length);
+        } else {
+          // We can't trim the beginning of this completion.
+          console.log(
+            '[Kite][Completer] Disposing of un-insertable completion: %s',
+            match.insertText ? match.insertText : match.label
+          );
+          return;
+        }
+      } else if (range.start.character > start.ch + 1) {
+        // The start of the completion can be 1 character past the start of the token,
+        // to accommodate completions after single character tokens like '.' or ' '.
+        // Completions that start further than that fall outside of the standard insertion range.
+        console.log(
+          '[Kite][Completer] Disposing of un-insertable completion: %s',
+          match.insertText ? match.insertText : match.label
+        );
+        return;
+      }
+      if (range.end.character > cursor.ch) {
+        // If the completion goes past the cursor, it is either a type-through completion,
+        // or it modifies characters past the cursor. However, the standard insertion range
+        // only extends past the cursor if all the completions are type-through, so no completions
+        // that modify characters past the cursor are insertable.
+        let postCursor = lineText.substring(cursor.ch, range.end.character);
+        if (insertion.endsWith(postCursor)) {
+          // This will result in the cursor being placed before what the user perceives
+          // as a type-through, instead of after it, which is not ideal.
+          insertion = insertion.substring(
+            0,
+            insertion.length - postCursor.length
+          );
+        } else {
+          // This completion modifies characters past the cursor, so it's un-insertable.
+          console.log(
+            '[Kite][Completer] Disposing of un-insertable completion: %s',
+            match.insertText ? match.insertText : match.label
+          );
+          return;
+        }
+      } else if (range.end.character < cursor.ch) {
+        // The end of the standard completion range will not be before the cursor.
+        // It is either on the cursor, or after it (in a type-through case).
+        // Therefore any completion that ends before the cursor cannot be inserted.
+        console.log(
+          '[Kite][Completer] Disposing of un-insertable completion: %s',
+          match.insertText ? match.insertText : match.label
+        );
+        return;
+      }
+      if (insertion !== match.insertText) {
+        console.log(
+          '[Kite][Completer] Trimmed %s => %s',
+          match.insertText,
+          insertion
+        );
+        match.insertText = insertion;
+      }
 
-             let completionItem = {
-               label: match.label,
-               insertText: match.insertText,
-               type: match.hint
-                 ? match.hint
-                 : match.kind
-                 ? completionItemKindNames[match.kind]
-                 : '',
-               icon: this.icon,
-               documentation: MarkupContent.is(match.documentation)
-                 ? match.documentation.value
-                 : match.documentation,
-               filterText: match.filterText,
-               deprecated: match.deprecated
-             };
+      let completionItem = {
+        label: match.label,
+        insertText: match.insertText,
+        type: match.hint
+          ? match.hint
+          : match.kind
+          ? completionItemKindNames[match.kind]
+          : '',
+        icon: this.icon,
+        documentation: MarkupContent.is(match.documentation)
+          ? match.documentation.value
+          : match.documentation,
+        filterText: match.filterText,
+        deprecated: match.deprecated
+      };
 
-             // Update prefix values
-             let text = match.insertText ? match.insertText : match.label;
-             if (text.toLowerCase().startsWith(prefix.toLowerCase())) {
-               all_non_prefixed = false;
-               if (prefix !== token.value) {
-                 if (text.toLowerCase().startsWith(token.value.toLowerCase())) {
-                   // given a completion insert text "display_table" and two test cases:
-                   // disp<tab>data →  display_table<cursor>data
-                   // disp<tab>lay  →  display_table<cursor>
-                   // we have to adjust the prefix for the latter (otherwise we would get display_table<cursor>lay),
-                   // as we are constrained NOT to replace after the prefix (which would be "disp" otherwise)
-                   prefix = token.value;
-                 }
-               }
-             }
+      // Update prefix values
+      let text = match.insertText ? match.insertText : match.label;
+      if (text.toLowerCase().startsWith(prefix.toLowerCase())) {
+        all_non_prefixed = false;
+        if (prefix !== token.value) {
+          if (text.toLowerCase().startsWith(token.value.toLowerCase())) {
+            // given a completion insert text "display_table" and two test cases:
+            // disp<tab>data →  display_table<cursor>data
+            // disp<tab>lay  →  display_table<cursor>
+            // we have to adjust the prefix for the latter (otherwise we would get display_table<cursor>lay),
+            // as we are constrained NOT to replace after the prefix (which would be "disp" otherwise)
+            prefix = token.value;
+          }
+        }
+      }
 
-             items.push(completionItem);
-           });
+      items.push(completionItem);
+    });
 
-           return {
-             // note in the ContextCompleter it was:
-             // start: token.offset,
-             // end: token.offset + token.value.length,
-             // which does not work with "from statistics import <tab>" as the last token ends at "t" of "import",
-             // so the completer would append "mean" as "from statistics importmean" (without space!);
-             // (in such a case the typedCharacters is undefined as we are out of range)
-             // a different workaround would be to prepend the token.value prefix:
-             // text = token.value + text;
-             // but it did not work for "from statistics <tab>" and lead to "from statisticsimport" (no space)
-             start: token.offset + (all_non_prefixed ? 1 : 0),
-             end: token.offset + prefix.length,
-             items
-           };
-         }
+    return {
+      // note in the ContextCompleter it was:
+      // start: token.offset,
+      // end: token.offset + token.value.length,
+      // which does not work with "from statistics import <tab>" as the last token ends at "t" of "import",
+      // so the completer would append "mean" as "from statistics importmean" (without space!);
+      // (in such a case the typedCharacters is undefined as we are out of range)
+      // a different workaround would be to prepend the token.value prefix:
+      // text = token.value + text;
+      // but it did not work for "from statistics <tab>" and lead to "from statisticsimport" (no space)
+      start: token.offset + (all_non_prefixed ? 1 : 0),
+      end: token.offset + prefix.length,
+      items
+    };
+  }
 
-         private merge_replies(
-           kernelReply: CompletionHandler.IReply,
-           kiteReply: CompletionHandler.ICompletionItemsReply
-         ): CompletionHandler.ICompletionItemsReply {
-           const newKernelReply = this.transform(kernelReply);
-           if (!newKernelReply.items.length) {
-             return kiteReply;
-           }
-           if (!kiteReply.items.length) {
-             return newKernelReply;
-           }
+  private merge_replies(
+    kernelReply: CompletionHandler.IReply,
+    kiteReply: CompletionHandler.ICompletionItemsReply
+  ): CompletionHandler.ICompletionItemsReply {
+    const newKernelReply = this.transform(kernelReply);
+    if (!newKernelReply.items.length) {
+      return kiteReply;
+    }
+    if (!kiteReply.items.length) {
+      return newKernelReply;
+    }
 
-           // Dedupe Kite and Kernel items based on label
-           const kiteSet = new Set(kiteReply.items.map(item => item.label));
-           newKernelReply.items = newKernelReply.items.filter(
-             item => !kiteSet.has(item.label)
-           );
+    // Dedupe Kite and Kernel items based on label
+    const kiteSet = new Set(kiteReply.items.map(item => item.label));
+    newKernelReply.items = newKernelReply.items.filter(
+      item => !kiteSet.has(item.label)
+    );
 
-           console.log('[Kite]: Merging', kiteReply, newKernelReply);
-           return {
-             ...kiteReply,
-             items: kiteReply.items.concat(newKernelReply.items)
-           };
-         }
+    console.log('[Kite]: Merging', kiteReply, newKernelReply);
+    return {
+      ...kiteReply,
+      items: kiteReply.items.concat(newKernelReply.items)
+    };
+  }
 
-         /**
-          * Converts an IReply into an ICompletionItemsReply.
-          */
-         private transform(
-           reply: CompletionHandler.IReply
-         ): CompletionHandler.ICompletionItemsReply {
-           const items = new Array<CompletionHandler.ICompletionItem>();
-           const metadata = reply.metadata || {};
-           const types = metadata._jupyter_types_experimental as JSONArray;
+  /**
+   * Converts an IReply into an ICompletionItemsReply.
+   */
+  private transform(
+    reply: CompletionHandler.IReply
+  ): CompletionHandler.ICompletionItemsReply {
+    const items = new Array<CompletionHandler.ICompletionItem>();
+    const metadata = reply.metadata || {};
+    const types = metadata._jupyter_types_experimental as JSONArray;
 
-           if (types) {
-             types.forEach((item: JSONObject) => {
-               const text = item.text as string;
-               const type = item.type as string;
-               items.push({
-                 label: text,
-                 type: type === '<unknown>' ? '' : type
-               });
-             });
-           } else {
-             const matches = reply.matches;
-             matches.forEach(match => {
-               items.push({ label: match });
-             });
-           }
-           return { start: reply.start, end: reply.end, items };
-         }
+    if (types) {
+      types.forEach((item: JSONObject) => {
+        const text = item.text as string;
+        const type = item.type as string;
+        items.push({ label: text, type: type === '<unknown>' ? '' : type });
+      });
+    } else {
+      const matches = reply.matches;
+      matches.forEach(match => {
+        items.push({ label: match });
+      });
+    }
+    return { start: reply.start, end: reply.end, items };
+  }
 
-         transform_from_editor_to_root(
-           position: CodeEditor.IPosition
-         ): IRootPosition {
-           let cm_editor = (this._editor as CodeMirrorEditor).editor;
-           let cm_start = PositionConverter.ce_to_cm(
-             position
-           ) as IEditorPosition;
-           return this.virtual_editor.transform_editor_to_root(
-             cm_editor,
-             cm_start
-           );
-         }
+  transform_from_editor_to_root(position: CodeEditor.IPosition): IRootPosition {
+    let cm_editor = (this._editor as CodeMirrorEditor).editor;
+    let cm_start = PositionConverter.ce_to_cm(position) as IEditorPosition;
+    return this.virtual_editor.transform_editor_to_root(cm_editor, cm_start);
+  }
 
-         get trigger_kind(): CompletionTriggerKind {
-           return this._trigger_kind;
-         }
+  get trigger_kind(): CompletionTriggerKind {
+    return this._trigger_kind;
+  }
 
-         set trigger_kind(kind: CompletionTriggerKind) {
-           this._trigger_kind = kind;
-         }
+  set trigger_kind(kind: CompletionTriggerKind) {
+    this._trigger_kind = kind;
+  }
 
-         with_trigger_kind(kind: CompletionTriggerKind, fn: Function) {
-           try {
-             this.trigger_kind = kind;
-             return fn();
-           } finally {
-             // Return to the default state
-             this.trigger_kind = CompletionTriggerKind.Invoked;
-           }
-         }
-       }
+  with_trigger_kind(kind: CompletionTriggerKind, fn: Function) {
+    try {
+      this.trigger_kind = kind;
+      return fn();
+    } finally {
+      // Return to the default state
+      this.trigger_kind = CompletionTriggerKind.Invoked;
+    }
+  }
+}
 
 /**
  * A namespace for Kite connector statics.

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/kite_model.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/kite_model.ts
@@ -7,60 +7,55 @@ import {
 import { Text } from '@jupyterlab/coreutils';
 
 export class KiteModel extends CompleterModel {
-         private _state: Completer.ITextState | undefined;
+  private _state: Completer.ITextState | undefined;
 
-         constructor() {
-           super();
-         }
+  constructor() {
+    super();
+  }
 
-         get state(): Completer.ITextState | undefined {
-           return this._state;
-         }
+  get state(): Completer.ITextState | undefined {
+    return this._state;
+  }
 
-         set state(newState: Completer.ITextState | undefined) {
-           this._state = newState;
-         }
+  set state(newState: Completer.ITextState | undefined) {
+    this._state = newState;
+  }
 
-         handleCursorChange(change: Completer.ITextState) {
-           super.handleCursorChange(change);
-           const prevState = this.state;
-           if (prevState) {
-             /**
-              * Reset model unless cursor change is result of typing a new character.
-              */
-             if (
-               change.column - prevState.column === 1 &&
-       
-               change.line - prevState.line === 0
-             ) {
-               return;
-             }
-             this.reset(true);
-           }
-         }
+  handleCursorChange(change: Completer.ITextState) {
+    super.handleCursorChange(change);
+    const prevState = this.state;
+    if (prevState) {
+      if (change.column - prevState.column === 1 && change.line - prevState.line === 0) {
+        // single char insertion
+        return;
+      }
+      if (change.column === 1 && change.line - prevState.line === 1) {
+        // newline insertion
+        return
+      }
+      // otherwise reset the model
+      this.reset(true);
+    }
+  }
 
-         handleTextChange(change: Completer.ITextState) {
-           super.handleTextChange(change);
-           this.state = change;
-         }
+  handleTextChange(change: Completer.ITextState) {
+    super.handleTextChange(change);
+    this.state = change;
+  }
 
-         /**
-          * Re-implementation of private method _updateModel.
-          * https://github.com/jupyterlab/jupyterlab/blob/1df0e18951194bb5ec230e76441e8108e0b472e7/packages/completer/src/handler.ts#L421
-          * Enables completer to fully update model state when completions are force updated in JupyterLabWidgetAdapter.
-          */
-         update(
-           reply: CompletionHandler.ICompletionItemsReply,
-           query: string,
-           state: Completer.ITextState
-         ) {
-           this.original = state;
-           this.query = query;
-           const text = state.text;
-           // Update the cursor.
-           this.cursor = {
-             start: Text.charIndexToJsIndex(reply.start, text),
-             end: Text.charIndexToJsIndex(reply.end, text)
-           };
-         }
-       }
+  /**
+   * Re-implementation of private method _updateModel.
+   * https://github.com/jupyterlab/jupyterlab/blob/1df0e18951194bb5ec230e76441e8108e0b472e7/packages/completer/src/handler.ts#L421
+   * Enables completer to fully update model state when completions are force updated in JupyterLabWidgetAdapter.
+   */
+  update(reply: CompletionHandler.ICompletionItemsReply, query: string, state: Completer.ITextState) {
+    this.original = state;
+    this.query = query;
+    const text = state.text;
+    // Update the cursor.
+    this.cursor = {
+      start: Text.charIndexToJsIndex(reply.start, text),
+      end: Text.charIndexToJsIndex(reply.end, text)
+    };
+  }
+}

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/kite_model.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/kite_model.ts
@@ -7,60 +7,60 @@ import {
 import { Text } from '@jupyterlab/coreutils';
 
 export class KiteModel extends CompleterModel {
-  private _state: Completer.ITextState | undefined;
+         private _state: Completer.ITextState | undefined;
 
-  constructor() {
-    super();
-  }
+         constructor() {
+           super();
+         }
 
-  get state(): Completer.ITextState | undefined {
-    return this._state;
-  }
+         get state(): Completer.ITextState | undefined {
+           return this._state;
+         }
 
-  set state(newState: Completer.ITextState | undefined) {
-    this._state = newState;
-  }
+         set state(newState: Completer.ITextState | undefined) {
+           this._state = newState;
+         }
 
-  handleCursorChange(change: Completer.ITextState) {
-    super.handleCursorChange(change);
-    const prevState = this.state;
-    if (prevState) {
-      /**
-       * Reset model unless cursor change is result of typing a new character.
-       */
-      if (
-        change.column - prevState.column === 1 ||
-        (change.line - prevState.line === 1 && change.column === 1)
-      ) {
-        return;
-      }
-      this.reset(true);
-    }
-  }
+         handleCursorChange(change: Completer.ITextState) {
+           super.handleCursorChange(change);
+           const prevState = this.state;
+           if (prevState) {
+             /**
+              * Reset model unless cursor change is result of typing a new character.
+              */
+             if (
+               change.column - prevState.column === 1 &&
+       
+               change.line - prevState.line === 0
+             ) {
+               return;
+             }
+             this.reset(true);
+           }
+         }
 
-  handleTextChange(change: Completer.ITextState) {
-    super.handleTextChange(change);
-    this.state = change;
-  }
+         handleTextChange(change: Completer.ITextState) {
+           super.handleTextChange(change);
+           this.state = change;
+         }
 
-  /**
-   * Re-implementation of private method _updateModel.
-   * https://github.com/jupyterlab/jupyterlab/blob/1df0e18951194bb5ec230e76441e8108e0b472e7/packages/completer/src/handler.ts#L421
-   * Enables completer to fully update model state when completions are force updated in JupyterLabWidgetAdapter.
-   */
-  update(reply: CompletionHandler.ICompletionItemsReply) {
-    if (this.state) {
-      const text = this.state.text;
-      const query = this.query;
-      // Update the original request.
-      this.original = this.state;
-      // Setting this.original resets the query string.
-      this.query = query;
-      // Update the cursor.
-      this.cursor = {
-        start: Text.charIndexToJsIndex(reply.start, text),
-        end: Text.charIndexToJsIndex(reply.end, text)
-      };
-    }
-  }
-}
+         /**
+          * Re-implementation of private method _updateModel.
+          * https://github.com/jupyterlab/jupyterlab/blob/1df0e18951194bb5ec230e76441e8108e0b472e7/packages/completer/src/handler.ts#L421
+          * Enables completer to fully update model state when completions are force updated in JupyterLabWidgetAdapter.
+          */
+         update(
+           reply: CompletionHandler.ICompletionItemsReply,
+           query: string,
+           state: Completer.ITextState
+         ) {
+           this.original = state;
+           this.query = query;
+           const text = state.text;
+           // Update the cursor.
+           this.cursor = {
+             start: Text.charIndexToJsIndex(reply.start, text),
+             end: Text.charIndexToJsIndex(reply.end, text)
+           };
+         }
+       }


### PR DESCRIPTION
fixes https://github.com/kiteco/kiteco/issues/11391

I tried multiple different approaches to fixing this:
- just fixing `KiteModel.update` isn't enough because that logic is only triggered if the completions panel is already visible.
    * but I'm convinced that logic was broken as well, and we just didn't see it
- for the "first trigger" case (when the panel isn't visible), the current approach is to just invoke completions via the standard JL machinery, so the bug seems likely to be in JL core, since none of that is our code.
    * to work around this, I cancel any in-flight (unreturned) completions requests per-keystroke
    * but we can't do this in the most sensible way because the `Completion.afterChange` runs asynchronously to receiving the edit, so it's possible we'd return before that function runs
    * so I put the logic to cancel in-flight completions requests very early in the edit handling path

The alternative to canceling in-flight requests is to trigger a custom flow when the completion panel is not visible (instead of the default JL flow) that does more checks to verify the completions aren't stale. But that seems harder right now.

@plungg can you check this? I am no longer able to trigger the issue. But it's conceivably possible that the race still exists, but is now just very unlikely (when working on this I had several intermediate solutions that made the race increasingly unlikely, but still trigger-able if you tried hard enough).