### PR TITLE
fix stale completer on cursor change

### DIFF
--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/kite_model.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/kite_model.ts
@@ -67,6 +67,7 @@ export class KiteModel extends CompleterModel {
 
   setCompletionItems(items: CompletionHandler.ICompletionItems) {
     if (this.isStale()) {
+      this.reset(true);
       return
     }
     super.setCompletionItems(items);
@@ -74,7 +75,6 @@ export class KiteModel extends CompleterModel {
 
   private isStale(): boolean {
     if (this.original.text !== this.state.text || this.original.line !== this.state.line || this.original.column !== this.state.column) {
-      this.reset(true);
       return true
     }
     return false;

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/kite_model.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/kite_model.ts
@@ -27,13 +27,16 @@ export class KiteModel extends CompleterModel {
     const prevState = this.state;
     this.state = change;
     if (prevState) {
-      if (change.column - prevState.column === 1 && change.line - prevState.line === 0) {
+      if (
+        change.column - prevState.column === 1 &&
+        change.line - prevState.line === 0
+      ) {
         // single char insertion
         return;
       }
       if (change.column === 1 && change.line - prevState.line === 1) {
         // newline insertion
-        return
+        return;
       }
       // otherwise reset the model
       this.reset(true);
@@ -50,7 +53,11 @@ export class KiteModel extends CompleterModel {
    * https://github.com/jupyterlab/jupyterlab/blob/1df0e18951194bb5ec230e76441e8108e0b472e7/packages/completer/src/handler.ts#L421
    * Enables completer to fully update model state when completions are force updated in JupyterLabWidgetAdapter.
    */
-  update(reply: CompletionHandler.ICompletionItemsReply, query: string, state: Completer.ITextState) {
+  update(
+    reply: CompletionHandler.ICompletionItemsReply,
+    query: string,
+    state: Completer.ITextState
+  ) {
     this.original = state;
     if (this.isStale()) {
       this.reset(true);
@@ -68,14 +75,18 @@ export class KiteModel extends CompleterModel {
   setCompletionItems(items: CompletionHandler.ICompletionItems) {
     if (this.isStale()) {
       this.reset(true);
-      return
+      return;
     }
     super.setCompletionItems(items);
   }
 
   private isStale(): boolean {
-    if (this.original.text !== this.state.text || this.original.line !== this.state.line || this.original.column !== this.state.column) {
-      return true
+    if (
+      this.original.text !== this.state.text ||
+      this.original.line !== this.state.line ||
+      this.original.column !== this.state.column
+    ) {
+      return true;
     }
     return false;
   }


### PR DESCRIPTION
fixes kiteco/kiteco#11469 I think

@plungg could you try this out a bit and see if you can repro? Also, can you try to repro kiteco/kiteco#11468 with this branch? I believe that they have the same underlying cause, but I'm not totally sure since it's hard for me to reproduce the latter.

I implement a more generalized way of detecting whether the state is stale when setting new completions items via `KiteModel.setCompletionItems` (called by the completions handler). I'm not sure if this has any negative consequences on filtering (particularly with Kernel completions), but it seems to work just fine. Please test it out yourselves as a sanity check.
