### PR TITLE
emit stateChanged signal in _resetKite

### DIFF
--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/kite_model.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/kite_model.ts
@@ -601,6 +601,7 @@ export class KiteModel {
     if (this._completionItems.length === 0) {
       this._reset();
     }
+    this._stateChanged.emit(undefined);
   }
 
   private isStale(check: Completer.ITextState = this._original): boolean {


### PR DESCRIPTION
Fixes kiteco/kiteco#11568 regression
Fixes kiteco/kiteco#11153 regression

If the signal is not sent when the model state is updated, the widget won't be updated to match that state, which results in issues such as the completer lingering after it's been reset.