### PR TITLE
Refactor Kite status bar and health checks

### DIFF
--- a/packages/jupyterlab-kite/package.json
+++ b/packages/jupyterlab-kite/package.json
@@ -77,6 +77,7 @@
     "jest": "^24.7.1",
     "jest-junit": "^8.0.0",
     "json-schema-to-typescript": "^8.0.0",
+    "lodash": "^4.17.20",
     "react": "*",
     "rimraf": "~2.6.2",
     "ts-jest": "^24.0.2",

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/components/status_model.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/components/status_model.ts
@@ -1,77 +1,88 @@
 import { VDomModel } from '@jupyterlab/apputils';
-import { PageConfig, URLExt } from '@jupyterlab/coreutils';
-import { ServerConnection } from '@jupyterlab/services';
 import { LabIcon } from '@jupyterlab/ui-components';
+
+import { isEqual } from 'lodash';
 
 import { JupyterLabWidgetAdapter } from '../jl_adapter';
 import { LSPConnection } from '../../../connection';
 import { DocumentConnectionManager } from '../../../connection_manager';
-import { ILanguageServerManager } from '../../../tokens';
 import { VirtualDocument } from '../../../virtual/document';
 
 import kiteLogo from '../../../../style/icons/kite-logo.svg';
+import { IDocumentInfo } from 'lsp-ws-connection';
+import { LanguageServerManager } from '../../../manager';
 
 export interface IKiteStatus {
   status: string;
   short: string;
   long: string;
 }
+
+export interface State {
+  disconnected: boolean;
+  kiteUninstalled: boolean;
+  serverUnreachable: boolean;
+  kiteStatus: IKiteStatus;
+}
+
 /**
  * A VDomModel for the LSP of current file editor/notebook.
  */
 export class KiteStatusModel extends VDomModel {
   private _connection_manager: DocumentConnectionManager;
+  private _language_server_manager: LanguageServerManager;
   private _icon: LabIcon = new LabIcon({
     name: 'jupyterlab-kite:status-icon',
     svgstr: kiteLogo
   });
-  private _kiteStatus: IKiteStatus | null = null;
-  private _installed = true;
-  private _disconnected = false;
+  private _state: State;
 
-  constructor() {
+  constructor(language_server_manager: LanguageServerManager) {
     super();
 
+    this._language_server_manager = language_server_manager;
     this.icon.bindprops({ className: 'kite-logo' });
+    this._state = {
+      kiteUninstalled: false,
+      serverUnreachable: false,
+      disconnected: false,
+      kiteStatus: { status: '', short: '', long: '' }
+    };
   }
 
-  async fetchKiteInstalled(): Promise<void> {
-    if (this._disconnected) {
+  async refresh(documentInfo: IDocumentInfo) {
+    if (this.state.disconnected) {
       return;
     }
 
-    const response = await ServerConnection.makeRequest(
-      this.kiteInstalledUrl,
-      { method: 'GET' },
-      ServerConnection.makeSettings()
-    );
-    if (!response.ok) {
-      console.warn('Could not fetch Kite Install status:', response.statusText);
-    }
-
-    let installed: boolean;
+    // Check /lsp/status for server reachability
     try {
-      installed = await response.json();
-      if (this._installed !== installed) {
-        this._installed = installed;
-        this._onChange();
-      }
+      await this.languageServerManager.fetchSessions();
     } catch (err) {
-      console.warn(err);
+      console.warn('Could not get server status:', err);
+      this.setState({ serverUnreachable: true });
+      return;
+    }
+
+    // Check if Kite engine is installed
+    const installed = await this.languageServerManager.fetchKiteInstalled();
+    if (!installed) {
+      console.warn('Kite engine not installed');
+      this.setState({ kiteUninstalled: true });
+      return;
+    }
+
+    // Get status from Kite Engine
+    if (this.activeConnection) {
+      const kiteStatus = await this.activeConnection.fetchKiteStatus(
+        documentInfo
+      );
+      this.setState({ kiteStatus });
     }
   }
 
-  get kiteInstalledUrl(): string {
-    return URLExt.join(
-      PageConfig.getBaseUrl(),
-      ILanguageServerManager.URL_NS,
-      'kite_installed'
-    );
-  }
-
-  set status(status: IKiteStatus | null) {
-    this._kiteStatus = status;
-    this._onChange();
+  get languageServerManager(): LanguageServerManager {
+    return this._language_server_manager;
   }
 
   get icon(): LabIcon {
@@ -79,35 +90,42 @@ export class KiteStatusModel extends VDomModel {
   }
 
   get reloadRequired(): boolean {
-    return this._disconnected;
+    return this.state.disconnected;
   }
 
-  get message(): {text: string, tooltip: string} {
-    if (this._disconnected) {
+  get message(): { text: string; tooltip: string } {
+    if (this.state.disconnected) {
       return {
         text: 'Kite: disconnected (reload page)',
-        tooltip: 'The connection to Kite was interrupted. Save your changes and reload the page to reconnect.',
+        tooltip:
+          'The connection to Kite was interrupted. Save your changes and reload the page to reconnect.'
       };
     }
 
-    // If we have a _kiteStatus, Kite must be conidered installed.
-    // This makes dev workflows work better.
-    if (this.adapter && this._kiteStatus) {
+    if (this.state.serverUnreachable) {
       return {
-        text: 'Kite: ' + this._kiteStatus.short,
-        tooltip: this._kiteStatus.long,
+        text: 'Kite: server extension unreachable',
+        tooltip: 'The jupyter-kite server extension could not be reached.'
       };
     }
 
-    if (!this._installed) {
+    if (this.state.kiteUninstalled) {
       return {
         text: 'Kite: not installed',
-        tooltip: 'Kite install could not be found.',
+        tooltip: 'Kite install could not be found.'
       };
     }
+
+    if (this.adapter && this.state.kiteStatus.status) {
+      return {
+        text: 'Kite: ' + this.state.kiteStatus.short,
+        tooltip: this.state.kiteStatus.long
+      };
+    }
+
     return {
       text: 'Kite: not running',
-      tooltip: 'Kite is not reachable.',
+      tooltip: 'Kite is not reachable.'
     };
   }
 
@@ -134,7 +152,7 @@ export class KiteStatusModel extends VDomModel {
   set connection_manager(connection_manager) {
     if (this._connection_manager != null) {
       this._connection_manager.connected.disconnect(this._onChange);
-      this._connection_manager.initialized.connect(this._onChange);
+      this._connection_manager.initialized.disconnect(this._onChange);
       this._connection_manager.closed.disconnect(this._connectionClosed);
       this._connection_manager.documents_changed.disconnect(this._onChange);
     }
@@ -165,10 +183,26 @@ export class KiteStatusModel extends VDomModel {
     return undefined;
   }
 
-  private _connectionClosed = () => {
-    this._disconnected = true;
-    this._onChange();
+  get state(): State {
+    return this._state;
   }
+
+  /**
+   * Loosely based on React's setState.
+   * Only signals a change if the potential new state
+   * is not deeply equal to the current state.
+   */
+  setState<K extends keyof State>(newValues: Pick<State, K>) {
+    const merged = { ...this._state, ...newValues };
+    if (!isEqual(this._state, merged)) {
+      this._state = merged;
+      this._onChange();
+    }
+  }
+
+  private _connectionClosed = () => {
+    this.setState({ disconnected: true });
+  };
 
   private _onChange = () => {
     this.stateChanged.emit(void 0);

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/components/status_model.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/components/status_model.ts
@@ -50,11 +50,7 @@ export class KiteStatusModel extends VDomModel {
     };
   }
 
-  async refresh(connection: LSPConnection, documentInfo: IDocumentInfo) {
-    if (this.reloadRequired) {
-      return;
-    }
-
+  async refresh(connection?: LSPConnection, documentInfo?: IDocumentInfo) {
     // Check /lsp/status for server reachability
     try {
       await this.languageServerManager.fetchSessions();
@@ -72,9 +68,15 @@ export class KiteStatusModel extends VDomModel {
       return;
     }
 
+    if (this.reloadRequired) {
+      return;
+    }
+
     // Get status from Kite Engine
-    const kiteStatus = await connection.fetchKiteStatus(documentInfo);
-    this.setState({ kiteStatus });
+    if (connection && documentInfo) {
+      const kiteStatus = await connection.fetchKiteStatus(documentInfo);
+      this.setState({ kiteStatus });
+    }
   }
 
   get languageServerManager(): LanguageServerManager {
@@ -90,14 +92,6 @@ export class KiteStatusModel extends VDomModel {
   }
 
   get message(): { text: string; tooltip: string } {
-    if (this.reloadRequired) {
-      return {
-        text: 'Kite: disconnected (reload page)',
-        tooltip:
-          'The connection to Kite was interrupted. Save your changes and reload the page to reconnect.'
-      };
-    }
-
     if (this.state.serverUnreachable) {
       return {
         text: 'Kite: server extension unreachable',
@@ -109,6 +103,14 @@ export class KiteStatusModel extends VDomModel {
       return {
         text: 'Kite: engine not installed',
         tooltip: 'Kite engine install could not be found.'
+      };
+    }
+
+    if (this.reloadRequired) {
+      return {
+        text: 'Kite: disconnected (reload page)',
+        tooltip:
+          'The connection to Kite was interrupted. Save your changes and reload the page to reconnect.'
       };
     }
 

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/components/status_model.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/components/status_model.ts
@@ -18,6 +18,8 @@ export interface IKiteStatus {
   long: string;
 }
 
+export const EmptyKiteStatus = { status: '', short: '', long: '' };
+
 export interface State {
   disconnected: boolean;
   kiteUninstalled: boolean;
@@ -46,7 +48,7 @@ export class KiteStatusModel extends VDomModel {
       kiteUninstalled: false,
       serverUnreachable: false,
       disconnected: false,
-      kiteStatus: { status: '', short: '', long: '' }
+      kiteStatus: EmptyKiteStatus
     };
   }
 
@@ -94,7 +96,7 @@ export class KiteStatusModel extends VDomModel {
   }
 
   get message(): { text: string; tooltip: string } {
-    if (this.state.disconnected) {
+    if (this.reloadRequired) {
       return {
         text: 'Kite: disconnected (reload page)',
         tooltip:

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/components/status_model.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/components/status_model.ts
@@ -51,7 +51,7 @@ export class KiteStatusModel extends VDomModel {
   }
 
   async refresh(documentInfo: IDocumentInfo) {
-    if (this.state.disconnected) {
+    if (this.reloadRequired) {
       return;
     }
 
@@ -111,8 +111,8 @@ export class KiteStatusModel extends VDomModel {
 
     if (this.state.kiteUninstalled) {
       return {
-        text: 'Kite: not installed',
-        tooltip: 'Kite install could not be found.'
+        text: 'Kite: engine not installed',
+        tooltip: 'Kite engine install could not be found.'
       };
     }
 

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/components/statusbar.tsx
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/components/statusbar.tsx
@@ -29,21 +29,25 @@ export class KiteStatus extends VDomRenderer<KiteStatusModel> {
    * Render the status item.
    */
   render() {
-    if (!this.model) {
+    if (!this.model || !this.model.activeDocument) {
       return null;
     }
 
+    console.log('Rendering KiteStatus');
+
     const activeDocument = this.model.activeDocument;
-    if (activeDocument && !(activeDocument.file_extension === 'py')) {
+    if (!(activeDocument.file_extension === 'py')) {
       this.setHidden(true);
       return null;
     }
 
-    this.model.fetchKiteInstalled();
+    if (activeDocument.document_info) {
+      this.model.refresh(activeDocument.document_info);
+    }
 
     const props: React.HTMLAttributes<HTMLDivElement> = {};
     if (this.model.reloadRequired) {
-      props.style = {cursor: 'pointer'};
+      props.style = { cursor: 'pointer' };
       props.onClick = () => window.location.reload();
     }
 

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/components/statusbar.tsx
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/components/statusbar.tsx
@@ -20,6 +20,7 @@ export class KiteStatus extends VDomRenderer<KiteStatusModel> {
    */
   constructor(model: KiteStatusModel) {
     super(model);
+    model.refresh();
     this.addClass(item);
     this.addClass('kite-statusbar-item');
     this.title.caption = 'Kite Status';

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/components/statusbar.tsx
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/components/statusbar.tsx
@@ -29,19 +29,16 @@ export class KiteStatus extends VDomRenderer<KiteStatusModel> {
    * Render the status item.
    */
   render() {
-    if (!this.model || !this.model.activeDocument) {
-      return null;
-    }
-
-    const activeDocument = this.model.activeDocument;
-    if (!(activeDocument.file_extension === 'py')) {
+    if (
+      !this.model ||
+      !this.model.adapter ||
+      this.model.adapter.language !== 'python'
+    ) {
       this.setHidden(true);
       return null;
     }
 
-    if (activeDocument.document_info) {
-      this.model.refresh(activeDocument.document_info);
-    }
+    this.setHidden(false);
 
     const props: React.HTMLAttributes<HTMLDivElement> = {};
     if (this.model.reloadRequired) {

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/components/statusbar.tsx
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/components/statusbar.tsx
@@ -3,6 +3,7 @@
 // Based on the @jupyterlab/codemirror-extension statusbar
 
 import React from 'react';
+import { extname } from 'path';
 
 import { VDomRenderer } from '@jupyterlab/apputils';
 import { GroupItem, item, TextItem } from '@jupyterlab/statusbar';
@@ -33,7 +34,8 @@ export class KiteStatus extends VDomRenderer<KiteStatusModel> {
     if (
       !this.model ||
       !this.model.adapter ||
-      this.model.adapter.language !== 'python'
+      // Other properties, such as adapter.language are not reliable when the server extension is not reachable
+      !this.isSupportedDocumentPath(this.model.adapter.document_path)
     ) {
       this.setHidden(true);
       return null;
@@ -53,5 +55,9 @@ export class KiteStatus extends VDomRenderer<KiteStatusModel> {
         <TextItem source={this.model.message.text} />
       </GroupItem>
     );
+  }
+
+  isSupportedDocumentPath(path: string) {
+    return extname(path) === '.py' || extname(path) === '.ipynb';
   }
 }

--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/components/statusbar.tsx
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/components/statusbar.tsx
@@ -33,8 +33,6 @@ export class KiteStatus extends VDomRenderer<KiteStatusModel> {
       return null;
     }
 
-    console.log('Rendering KiteStatus');
-
     const activeDocument = this.model.activeDocument;
     if (!(activeDocument.file_extension === 'py')) {
       this.setHidden(true);

--- a/packages/jupyterlab-kite/src/connection.ts
+++ b/packages/jupyterlab-kite/src/connection.ts
@@ -71,21 +71,16 @@ export class LSPConnection extends LspWsConnection {
     return '';
   }
 
-  async fetchKiteStatus(documentInfo: IDocumentInfo) {
+  async fetchKiteStatus(documentInfo: IDocumentInfo): Promise<IKiteStatus> {
     let result: IKiteStatus;
     try {
       result = await this.connection.sendRequest('kite/status', {
         uri: documentInfo.uri
       });
-      if (this.status_model) {
-        this.status_model.status = result;
-      }
-    } catch {
-      console.warn('Kite Status could not be fetched. Setting to not ready.');
-      if (this.status_model) {
-        this.status_model.status = null;
-      }
+    } catch (err) {
+      console.warn('Could not fetch Kite Status:', err);
     }
+    return result;
   }
 
   sendSelection(
@@ -102,7 +97,7 @@ export class LSPConnection extends LspWsConnection {
     } catch (e) {
       console.warn('[Kite] Selection Notification Error:', e);
     }
-    this.fetchKiteStatus(documentInfo);
+    this.status_model.refresh(documentInfo);
   }
 
   public sendSelectiveChange(
@@ -192,7 +187,7 @@ export class LSPConnection extends LspWsConnection {
 
   private _sendOpen(documentInfo: IDocumentInfo) {
     this.sendOpen(documentInfo);
-    this.fetchKiteStatus(documentInfo);
+    this.status_model.refresh(documentInfo);
   }
 
   private _sendChange(
@@ -214,6 +209,6 @@ export class LSPConnection extends LspWsConnection {
       textDocumentChange
     );
     documentInfo.version++;
-    this.fetchKiteStatus(documentInfo);
+    this.status_model.refresh(documentInfo);
   }
 }

--- a/packages/jupyterlab-kite/src/connection.ts
+++ b/packages/jupyterlab-kite/src/connection.ts
@@ -98,7 +98,7 @@ export class LSPConnection extends LspWsConnection {
     } catch (e) {
       console.warn('[Kite] Selection Notification Error:', e);
     }
-    this.status_model?.refresh(documentInfo);
+    this.status_model?.refresh(this, documentInfo);
   }
 
   public sendSelectiveChange(
@@ -188,7 +188,7 @@ export class LSPConnection extends LspWsConnection {
 
   private _sendOpen(documentInfo: IDocumentInfo) {
     this.sendOpen(documentInfo);
-    this.status_model?.refresh(documentInfo);
+    this.status_model?.refresh(this, documentInfo);
   }
 
   private _sendChange(
@@ -210,6 +210,6 @@ export class LSPConnection extends LspWsConnection {
       textDocumentChange
     );
     documentInfo.version++;
-    this.status_model?.refresh(documentInfo);
+    this.status_model?.refresh(this, documentInfo);
   }
 }

--- a/packages/jupyterlab-kite/src/connection.ts
+++ b/packages/jupyterlab-kite/src/connection.ts
@@ -13,7 +13,8 @@ import {
 import { until_ready } from './utils';
 import {
   KiteStatusModel,
-  IKiteStatus
+  IKiteStatus,
+  EmptyKiteStatus
 } from './adapters/jupyterlab/components/status_model';
 
 interface ILSPOptions extends ILspOptions {
@@ -72,7 +73,7 @@ export class LSPConnection extends LspWsConnection {
   }
 
   async fetchKiteStatus(documentInfo: IDocumentInfo): Promise<IKiteStatus> {
-    let result: IKiteStatus;
+    let result = EmptyKiteStatus;
     try {
       result = await this.connection.sendRequest('kite/status', {
         uri: documentInfo.uri
@@ -97,7 +98,7 @@ export class LSPConnection extends LspWsConnection {
     } catch (e) {
       console.warn('[Kite] Selection Notification Error:', e);
     }
-    this.status_model.refresh(documentInfo);
+    this.status_model?.refresh(documentInfo);
   }
 
   public sendSelectiveChange(
@@ -187,7 +188,7 @@ export class LSPConnection extends LspWsConnection {
 
   private _sendOpen(documentInfo: IDocumentInfo) {
     this.sendOpen(documentInfo);
-    this.status_model.refresh(documentInfo);
+    this.status_model?.refresh(documentInfo);
   }
 
   private _sendChange(
@@ -209,6 +210,6 @@ export class LSPConnection extends LspWsConnection {
       textDocumentChange
     );
     documentInfo.version++;
-    this.status_model.refresh(documentInfo);
+    this.status_model?.refresh(documentInfo);
   }
 }

--- a/packages/jupyterlab-kite/src/index.ts
+++ b/packages/jupyterlab-kite/src/index.ts
@@ -88,7 +88,6 @@ const plugin: JupyterFrontEndPlugin<void> = {
       connection_manager
     );
     const status_bar_item = new KiteStatus(kite_status_model);
-    status_bar_item.model.connection_manager = connection_manager;
 
     labShell.currentChanged.connect(() => {
       const current = labShell.currentWidget;

--- a/packages/jupyterlab-kite/src/index.ts
+++ b/packages/jupyterlab-kite/src/index.ts
@@ -68,7 +68,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     registerKiteCommands(app, palette);
 
     const language_server_manager = new LanguageServerManager({});
-    const kite_status_model = new KiteStatusModel();
+    const kite_status_model = new KiteStatusModel(language_server_manager);
     const connection_manager = new DocumentConnectionManager({
       language_server_manager,
       kite_status_model
@@ -76,7 +76,8 @@ const plugin: JupyterFrontEndPlugin<void> = {
     const ka = await KiteAccessible.CreateAsync(
       app.serviceManager,
       settingRegistry,
-      connection_manager
+      connection_manager,
+      language_server_manager
     );
     ka.checkHealth();
     const onboarding_manager = new KiteOnboarding(

--- a/packages/jupyterlab-kite/src/index.ts
+++ b/packages/jupyterlab-kite/src/index.ts
@@ -154,9 +154,6 @@ const plugin: JupyterFrontEndPlugin<void> = {
           widget.disposed.disconnect(disconnect);
           widget.context.pathChanged.disconnect(reconnect);
           adapter.dispose();
-          if (status_bar_item.model.adapter === adapter) {
-            status_bar_item.model.adapter = null;
-          }
         };
 
         const reconnect = () => {
@@ -166,8 +163,6 @@ const plugin: JupyterFrontEndPlugin<void> = {
 
         widget.disposed.connect(disconnect);
         widget.context.pathChanged.connect(reconnect);
-
-        status_bar_item.model.adapter = adapter;
       }
     };
 
@@ -194,9 +189,6 @@ const plugin: JupyterFrontEndPlugin<void> = {
         widget.disposed.disconnect(disconnect);
         widget.context.pathChanged.disconnect(reconnect);
         adapter.dispose();
-        if (status_bar_item.model.adapter === adapter) {
-          status_bar_item.model.adapter = null;
-        }
       };
 
       const reconnect = () => {
@@ -206,8 +198,6 @@ const plugin: JupyterFrontEndPlugin<void> = {
 
       widget.context.pathChanged.connect(reconnect);
       widget.disposed.connect(disconnect);
-
-      status_bar_item.model.adapter = adapter;
     };
 
     notebookTracker.widgetAdded.connect(async (sender, widget) => {

--- a/packages/jupyterlab-kite/src/manager.ts
+++ b/packages/jupyterlab-kite/src/manager.ts
@@ -99,7 +99,7 @@ export class LanguageServerManager implements ILanguageServerManager {
     const resp = await ServerConnection.makeRequest(
       this.kiteInstalledUrl,
       { method: 'GET' },
-      ServerConnection.makeSettings()
+      this._settings
     );
     return resp.ok && (await resp.json());
   }

--- a/packages/jupyterlab-kite/src/manager.ts
+++ b/packages/jupyterlab-kite/src/manager.ts
@@ -86,4 +86,21 @@ export class LanguageServerManager implements ILanguageServerManager {
 
     this._sessionsChanged.emit(void 0);
   }
+
+  get kiteInstalledUrl(): string {
+    return URLExt.join(
+      PageConfig.getBaseUrl(),
+      ILanguageServerManager.URL_NS,
+      'kite_installed'
+    );
+  }
+
+  async fetchKiteInstalled(): Promise<boolean> {
+    const resp = await ServerConnection.makeRequest(
+      this.kiteInstalledUrl,
+      { method: 'GET' },
+      ServerConnection.makeSettings()
+    );
+    return resp.ok && (await resp.json());
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1887,7 +1887,7 @@
     typestyle "^2.0.4"
 
 "@kiteco/jupyterlab-kite@file:packages/jupyterlab-kite":
-  version "1.0.0"
+  version "1.1.0"
   dependencies:
     "@krassowski/jupyterlab_go_to_definition" "~1.0.0"
     jupyterlab_toastify "^4.1.2"
@@ -8850,6 +8850,11 @@ lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+lodash@^4.17.20:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 log-symbols@2.2.0, log-symbols@^2.1.0:
   version "2.2.0"


### PR DESCRIPTION
<img width="1818" alt="Screen Shot 2020-10-08 at 5 36 29 PM" src="https://user-images.githubusercontent.com/47993402/95528447-0393f900-098d-11eb-8ec3-0cafc58911aa.png">

- Add status message and notification for when the server extension is unreachable
- Use same implementation of `fetchKiteInstall` for status model and `KiteAccessible`
- Clean up logic:
  - `fetchKiteStatus` and `fetchKiteInstalled` now return Promises that return the appropriate value, making upstream callers handle setting of state instead
  - Create state object in Kite Status Model.
    - `KiteStatus` is no longer nullable
    - state object is source of truth for `disconnected`, `kiteUninstalled`, and `serverUnreachable`
  - Create a `setState` method in the kite server model, which only emits state changes when necessary, to prevent loop where we render, check state, emit state changes, then render in response
  - Remove `activeDocument`, which was flaky, and use `adapter` values instead
  - Remove `activeConnection` and references to `_connection_manager`, fixing circular dependency where the status model held a reference to the connection manager, while the connection manager held a reference to the model.
  - Reorder status check and and messaging logic, so that more specific failures such as kite engine or jupyter-kite not being present would come before `reloadRequired`.