### PR TITLE
Check optional LSPCompletionItem properties

### DIFF
--- a/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
+++ b/packages/jupyterlab-kite/src/adapters/jupyterlab/components/completion.ts
@@ -286,63 +286,65 @@ export class KiteConnector extends DataConnector<
       .map(token => token.string)
       .join('');
     (lspCompletionItems as IKiteLSPCompletionItem[]).forEach(match => {
-      let range = match.textEdit.range;
+      let range = match.textEdit?.range;
       let insertion = match.insertText ? match.insertText : match.label;
-      if (range.start.character < start.ch) {
-        // If this completion begins before the given token begins,
-        // we need to trim it so that it begins within the given token instead.
-        let preToken = lineText.substring(range.start.character, start.ch);
-        if (insertion.startsWith(preToken)) {
-          // We can trim this completion because the trimmed portion will match the existing text in the line.
-          insertion = insertion.substring(preToken.length);
-        } else {
-          // We can't trim the beginning of this completion.
+      if (range) {
+        if (range.start.character < start.ch) {
+          // If this completion begins before the given token begins,
+          // we need to trim it so that it begins within the given token instead.
+          let preToken = lineText.substring(range.start.character, start.ch);
+          if (insertion.startsWith(preToken)) {
+            // We can trim this completion because the trimmed portion will match the existing text in the line.
+            insertion = insertion.substring(preToken.length);
+          } else {
+            // We can't trim the beginning of this completion.
+            console.log(
+              '[Kite][Completer] Disposing of un-insertable completion: %s',
+              match.insertText ? match.insertText : match.label
+            );
+            return;
+          }
+        } else if (range.start.character > start.ch + 1) {
+          // The start of the completion can be 1 character past the start of the token,
+          // to accommodate completions after single character tokens like '.' or ' '.
+          // Completions that start further than that fall outside of the standard insertion range.
           console.log(
             '[Kite][Completer] Disposing of un-insertable completion: %s',
             match.insertText ? match.insertText : match.label
           );
           return;
         }
-      } else if (range.start.character > start.ch + 1) {
-        // The start of the completion can be 1 character past the start of the token,
-        // to accommodate completions after single character tokens like '.' or ' '.
-        // Completions that start further than that fall outside of the standard insertion range.
-        console.log(
-          '[Kite][Completer] Disposing of un-insertable completion: %s',
-          match.insertText ? match.insertText : match.label
-        );
-        return;
-      }
-      if (range.end.character > cursor.ch) {
-        // If the completion goes past the cursor, it is either a type-through completion,
-        // or it modifies characters past the cursor. However, the standard insertion range
-        // only extends past the cursor if all the completions are type-through, so no completions
-        // that modify characters past the cursor are insertable.
-        let postCursor = lineText.substring(cursor.ch, range.end.character);
-        if (insertion.endsWith(postCursor)) {
-          // This will result in the cursor being placed before what the user perceives
-          // as a type-through, instead of after it, which is not ideal.
-          insertion = insertion.substring(
-            0,
-            insertion.length - postCursor.length
-          );
-        } else {
-          // This completion modifies characters past the cursor, so it's un-insertable.
+        if (range.end.character > cursor.ch) {
+          // If the completion goes past the cursor, it is either a type-through completion,
+          // or it modifies characters past the cursor. However, the standard insertion range
+          // only extends past the cursor if all the completions are type-through, so no completions
+          // that modify characters past the cursor are insertable.
+          let postCursor = lineText.substring(cursor.ch, range.end.character);
+          if (insertion.endsWith(postCursor)) {
+            // This will result in the cursor being placed before what the user perceives
+            // as a type-through, instead of after it, which is not ideal.
+            insertion = insertion.substring(
+              0,
+              insertion.length - postCursor.length
+            );
+          } else {
+            // This completion modifies characters past the cursor, so it's un-insertable.
+            console.log(
+              '[Kite][Completer] Disposing of un-insertable completion: %s',
+              match.insertText ? match.insertText : match.label
+            );
+            return;
+          }
+        } else if (range.end.character < cursor.ch) {
+          // The end of the standard completion range will not be before the cursor.
+          // It is either on the cursor, or after it (in a type-through case).
+          // Therefore any completion that ends before the cursor cannot be inserted.
           console.log(
             '[Kite][Completer] Disposing of un-insertable completion: %s',
             match.insertText ? match.insertText : match.label
           );
           return;
         }
-      } else if (range.end.character < cursor.ch) {
-        // The end of the standard completion range will not be before the cursor.
-        // It is either on the cursor, or after it (in a type-through case).
-        // Therefore any completion that ends before the cursor cannot be inserted.
-        console.log(
-          '[Kite][Completer] Disposing of un-insertable completion: %s',
-          match.insertText ? match.insertText : match.label
-        );
-        return;
       }
       if (insertion !== match.insertText) {
         console.log(
@@ -366,7 +368,6 @@ export class KiteConnector extends DataConnector<
           ? match.documentation.value
           : match.documentation,
         filterText: match.filterText,
-        deprecated: match.deprecated,
         noFilter: true
       };
 


### PR DESCRIPTION
Fixes MacOS build where JupyterLab completions were not appearing.

`textEdit` is an optional property in `LSPCompletionItem` that we previously didn't use, but use now in `kite-lsp`. Regardless, added checks for its existence (and therefore `range`). Also, removed `deprecated` property, which JL core has marked as deprecated.