### PR TITLE
Define minimum version of tornado in install_requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ zip_safe = False
 
 install_requires =
     notebook >=4.3.1
+    tornado >=5.1.0
     setuptools
 
 [options.packages.find]


### PR DESCRIPTION
Based on my testing, version 5.1.0 of tornado is the earliest version that our extension will support.

Once this was added, if I attempted to install the extension, it would auto upgrade tornado to 6.0.4.